### PR TITLE
Fix win64 vcrun2015 builds

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,3 +1,10 @@
+# Release 3.2.2.1
+
+ * PPA built with libsecp256k1-0, python3-pycryptodome dependencies
+ * Added dark theme
+ * Fix ecc_fast.py for win64
+ * Fix vcrun2015 in win64 builds
+
 # Release 3.2.2
 
  * Fix DNS resolution on Windows

--- a/contrib/dash/travis/Dockerfile-wine
+++ b/contrib/dash/travis/Dockerfile-wine
@@ -53,8 +53,14 @@ ENV WINEARCH win64
 ENV PYHOME $WINEPREFIX/drive_c/Python35
 
 RUN echo 'download and install 64-bit Python/pywin32/PyQt/git/NSIS' \
-    && wineboot -i \
-    && xvfb-run -a winetricks -q vcrun2015 && winetricks win10 \
+    && wineboot -i && winetricks win10 \
+    && wget -nv https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe \
+    && cabextract -d ex vc_redist.x64.exe && rm vc_redist.x64.exe \
+    && cabextract -d ex/a10ex ex/a10 && cabextract -d ex/a11ex ex/a11 \
+    && for f in ex/a10ex/api_ms_win_*; do mv $f $(echo "$f" | sed s/_/-/g); done \
+    && cp ex/a10ex/* $WINEPREFIX/drive_c/windows/system32 \
+    && cp ex/a11ex/* $WINEPREFIX/drive_c/windows/system32 \
+    && rm -rf ex \
     \
     && wget -nv -O python.exe https://www.python.org/ftp/python/3.5.4/python-3.5.4-amd64.exe \
     && xvfb-run -a wine python.exe /quiet InstallAllUsers=1 TargetDir=$PYHOME && rm python.exe \

--- a/lib/version.py
+++ b/lib/version.py
@@ -1,5 +1,5 @@
-ELECTRUM_VERSION = '3.2.2'   # version of the client package
-APK_VERSION = '3.2.2.0'      # read by buildozer.spec
+ELECTRUM_VERSION = '3.2.2.1'   # version of the client package
+APK_VERSION = '3.2.2.1'      # read by buildozer.spec
 
 PROTOCOL_VERSION = '1.2'     # protocol version requested
 


### PR DESCRIPTION
- change Dockerfile to install vcrun2015 x64 manually instead using winetricks (docker image on hub.docker.com is already rebuilded)
- version to 3.2.2.1, add relnotes