### PR TITLE
fix trezor Dash coin name for testnet

### DIFF
--- a/plugins/trezor/trezor.py
+++ b/plugins/trezor/trezor.py
@@ -167,7 +167,7 @@ class TrezorPlugin(HW_PluginBase):
         return client
 
     def get_coin_name(self):
-        return "DashTestnet" if constants.net.TESTNET else "Dash"
+        return "Dash Testnet" if constants.net.TESTNET else "Dash"
 
     def initialize_device(self, device_id, wizard, handler):
         # Initialization method


### PR DESCRIPTION
https://github.com/akhavr/electrum-dash/issues/44

In old trezor-common code there was no coin definition
for Dash testnet, so previous name was get without space.