### PR TITLE
Fix rename app in PR #51

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ deploy:
   - build/electrum-dash/dist/Dash-Electrum-$DASH_ELECTRUM_VERSION.tar.gz
   - build/electrum-dash/dist/Dash-Electrum-$DASH_ELECTRUM_VERSION-setup-win32.exe
   - build/electrum-dash/dist/Dash-Electrum-$DASH_ELECTRUM_VERSION-setup-win64.exe
-  - build/electrum-dash/bin/Dash_Electrum-$DASH_ELECTRUM_APK_VERSION-release-unsigned.apk
+  - build/electrum-dash/bin/Electrum_DASH-$DASH_ELECTRUM_APK_VERSION-release-unsigned.apk
   on:
     repo: akhavr/electrum-dash
     tags: true

--- a/contrib/sign-releases.py
+++ b/contrib/sign-releases.py
@@ -29,7 +29,7 @@ Manual signing:
         -sigalg SHA1withRSA -digestalg SHA1 \
         -sigfile dash-electrum \
         -keystore ~/.jks/keystore \
-        Dash_Electrum-3.0.6.1-release-unsigned.apk \
+        Electrum_DASH-3.0.6.1-release-unsigned.apk \
         electrum.dash.org
 
 Zipalign from Android SDK build tools is also required (set path to bin in
@@ -48,8 +48,8 @@ settings file or with key -z). To install:
 Manual zip aligning:
 
     android-sdk-linux/build-tools/27.0.3/zipalign -v 4 \
-        Dash_Electrum-3.0.6.1-release-unsigned.apk \
-        Dash_Electrum-3.0.6.1-release.apk
+        Electrum_DASH-3.0.6.1-release-unsigned.apk \
+        Dash-Electrum-3.0.6.1-release.apk
 
 
 
@@ -168,8 +168,8 @@ JARSIGNER_ARGS = [
     '-storepass:env', JKS_STOREPASS,
     '-keypass:env', JKS_KEYPASS,
 ]
-UNSIGNED_APK_PATTERN = re.compile('^Dash_Electrum-(.*)-release-unsigned.apk$')
-SIGNED_APK_TEMPLATE = 'Dash_Electrum-{version}-release.apk'
+UNSIGNED_APK_PATTERN = re.compile('^Electrum_DASH-(.*)-release-unsigned.apk$')
+SIGNED_APK_TEMPLATE = 'Dash-Electrum-{version}-release.apk'
 
 
 os.environ['QUILT_PATCHES'] = 'debian/patches'

--- a/electrum_dash/gui/kivy/tools/buildozer.spec
+++ b/electrum_dash/gui/kivy/tools/buildozer.spec
@@ -4,7 +4,7 @@
 title = Dash-Electrum
 
 # (str) Package name
-package.name = Dash_Electrum
+package.name = Electrum_DASH
 
 # (str) Package domain (needed for android/ios packaging)
 package.domain = org.dash.electrum


### PR DESCRIPTION
- Back to `Electrum_DASH` package name
- rename to `Dash-Electrum` during release signing process
- additional improvement for release signing: set release name/body (description) when making ppa