### PR TITLE
fix sign/encrypt msg fields not to accept rich text

### DIFF
--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -2306,6 +2306,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         layout = QGridLayout(d)
 
         message_e = QTextEdit()
+        message_e.setAcceptRichText(False)
         layout.addWidget(QLabel(_('Message')), 1, 0)
         layout.addWidget(message_e, 1, 1)
         layout.setRowStretch(2,3)
@@ -2316,6 +2317,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         layout.addWidget(address_e, 2, 1)
 
         signature_e = QTextEdit()
+        signature_e.setAcceptRichText(False)
         layout.addWidget(QLabel(_('Signature')), 3, 0)
         layout.addWidget(signature_e, 3, 1)
         layout.setRowStretch(3,1)
@@ -2372,6 +2374,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         layout = QGridLayout(d)
 
         message_e = QTextEdit()
+        message_e.setAcceptRichText(False)
         layout.addWidget(QLabel(_('Message')), 1, 0)
         layout.addWidget(message_e, 1, 1)
         layout.setRowStretch(2,3)
@@ -2384,6 +2387,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         layout.addWidget(pubkey_e, 2, 1)
 
         encrypted_e = QTextEdit()
+        encrypted_e.setAcceptRichText(False)
         layout.addWidget(QLabel(_('Encrypted')), 3, 0)
         layout.addWidget(encrypted_e, 3, 1)
         layout.setRowStretch(3,1)

--- a/electrum_dash/util.py
+++ b/electrum_dash/util.py
@@ -595,17 +595,17 @@ def time_difference(distance_in_time, include_seconds):
         return "over %d years" % (round(distance_in_minutes / 525600))
 
 mainnet_block_explorers = {
-    'Dash.org': ('https://insight.dash.org/insight/',
-                       {'tx': 'tx/', 'addr': 'address/'}),
-    'Bchain.info': ('https://bchain.info/DASH/',
-                       {'tx': 'tx/', 'addr': 'addr/'}),
+    'Dash.org': ('https://explorer.dash.org/',
+                 {'tx': 'tx/', 'addr': 'address/'}),
+    'Insight.dash.org': ('https://insight.dash.org/insight/',
+                         {'tx': 'tx/', 'addr': 'address/'}),
     'system default': ('blockchain:/',
                        {'tx': 'tx/', 'addr': 'address/'}),
 }
 
 testnet_block_explorers = {
     'Dash.org': ('https://testnet-insight.dashevo.org/insight/',
-                       {'tx': 'tx/', 'addr': 'address/'}),
+                 {'tx': 'tx/', 'addr': 'address/'}),
     'system default': ('blockchain:/',
                        {'tx': 'tx/', 'addr': 'address/'}),
 }


### PR DESCRIPTION
When copying text of message to sign from rich text editors, there is rich formating copied together with text and confusions possible during verify process. This patch disables acceptRichText on QTextEdit field for message.