### PR TITLE
Fix get balance for ps balance when ps_others exists

### DIFF
--- a/contrib/sign-releases.py
+++ b/contrib/sign-releases.py
@@ -136,7 +136,6 @@ SHA_FNAME = 'SHA256SUMS.txt'
 PPA_SERIES = {
     'xenial': '16.04.1',
     'bionic': '18.04.1',
-    'disco': '19.04.1',
     'eoan': '19.10.1',
     'focal': '20.04.1',
 }

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -1494,7 +1494,6 @@ class PSManager(Logger):
         dn_balance = sum(w.get_balance(include_ps=False, min_rounds=0))
         if dn_balance == 0:
             return 0
-        dn_balance = sum(w.get_balance(include_ps=False, min_rounds=0))
         r = self.mix_rounds if count_on_rounds is None else count_on_rounds
         ps_balance = sum(w.get_balance(include_ps=False, min_rounds=r))
         if dn_balance == ps_balance:

--- a/electrum_dash/tests/test_dash_ps.py
+++ b/electrum_dash/tests/test_dash_ps.py
@@ -450,6 +450,46 @@ class PSWalletTestCase(TestCaseForTestnet):
         assert wallet.get_balance(include_ps=False, min_rounds=0) == \
             (500005000, 0, 0)
 
+        # check balance with ps_other
+        w = wallet
+        coins = w.get_spendable_coins(domain=None, config=self.config)
+        denom_addr = list(w.db.get_ps_denoms().values())[0][0]
+        outputs = [TxOutput(TYPE_ADDRESS, denom_addr, 300000)]
+        tx = w.make_unsigned_transaction(coins, outputs, config=self.config)
+        w.sign_transaction(tx, None)
+        txid = tx.txid()
+        w.add_transaction(txid, tx)
+        w.db.add_islock(txid)
+
+        # check when transaction is standard
+        assert wallet.get_balance() == (1484831547, 0, 0)
+        assert wallet.get_balance(include_ps=False) == (984506547, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=5) == (0, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=4) == (0, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=3) == (0, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=2) == \
+            (384803848, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=1) == \
+            (384903849, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=0) == \
+            (500005000, 0, 0)
+
+        coro = psman.find_untracked_ps_txs(log=True)
+        asyncio.get_event_loop().run_until_complete(coro)
+
+        # check when transaction is other ps coins
+        assert wallet.get_balance() == (1484831547, 0, 0)
+        assert wallet.get_balance(include_ps=False) == (984506547, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=5) == (0, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=4) == (0, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=3) == (0, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=2) == \
+            (384803848, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=1) == \
+            (384903849, 0, 0)
+        assert wallet.get_balance(include_ps=False, min_rounds=0) == \
+            (500005000, 0, 0)
+
     def test_get_ps_addresses(self):
         C_RNDS = PSCoinRounds.COLLATERAL
         assert self.wallet.db.get_ps_addresses() == set()


### PR DESCRIPTION
- Fix get_balance bug when min_rounds >= 0 and ps_other with same address as ps_denom exists
- rm excess get_balance call from psman.mixing_progress
- rm disco build from contrib/sign-releases.py (End of Life on January 23, 2020)