### PR TITLE
PS block receving gui when mixing

### DIFF
--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -736,6 +736,8 @@ class PSManager(Logger):
     ADD_PS_DATA_ERR_MSG = _('Error on adding PrivateSend transaction data.')
     SPEND_TO_PS_ADDRS_MSG = _('For privacy reasons blocked attempt to'
                               ' transfer coins to PrivateSend address.')
+    WATCHING_ONLY_MSG = _('This is a watching-only wallet.'
+                          ' Mixing can not be run.')
     ALL_MIXED_MSG = _('PrivateSend mixing is done')
     CLEAR_PS_DATA_MSG = _('Are you sure to clear all wallet PrivateSend data?'
                           ' This is not recommended if there is'
@@ -1973,7 +1975,9 @@ class PSManager(Logger):
     def start_mixing(self, password, nowait=True):
         w = self.wallet
         msg = None
-        if self.all_mixed and not self.calc_need_denoms_amounts():
+        if w.is_watching_only():
+            msg = self.WATCHING_ONLY_MSG, 'err'
+        elif self.all_mixed and not self.calc_need_denoms_amounts():
             msg = self.ALL_MIXED_MSG, 'inf'
         elif not self.network or not self.network.is_connected():
             msg = self.NO_NETWORK_MSG, 'err'

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -738,6 +738,11 @@ class PSManager(Logger):
                               ' transfer coins to PrivateSend address.')
     WATCHING_ONLY_MSG = _('This is a watching-only wallet.'
                           ' Mixing can not be run.')
+    RECV_BLOCKED_MSG = _('To prevent interfering with PrivateSend mixing'
+                         ' process, where addresses is actively reserved'
+                         ' for PrivateSend use, this GUI functionality is'
+                         ' temporarily blocked. To unblock it stop'
+                         ' PrivateSend mixing.')
     ALL_MIXED_MSG = _('PrivateSend mixing is done')
     CLEAR_PS_DATA_MSG = _('Are you sure to clear all wallet PrivateSend data?'
                           ' This is not recommended if there is'

--- a/electrum_dash/gui/kivy/main_window.py
+++ b/electrum_dash/gui/kivy/main_window.py
@@ -807,6 +807,7 @@ class ElectrumWindow(App):
         Clock.schedule_once(lambda dt: self.on_ps_event(event, *args))
 
     def on_ps_event(self, event, *args):
+        psman = self.wallet.psman
         if event == 'ps-data-changes':
             wallet = args[0]
             if wallet == self.wallet:
@@ -818,20 +819,18 @@ class ElectrumWindow(App):
         elif event == 'ps-state-changes':
             wallet, msg, msg_type = args
             if wallet == self.wallet:
-                self.update_ps_btn()
+                is_mixing = (psman.state in psman.mixing_running_states)
+                self.update_ps_btn(is_mixing)
+                if self.receive_screen:
+                    self.receive_screen.block_on_mixing(is_mixing)
                 if msg:
                     if msg_type and msg_type.startswith('inf'):
                         self.show_info(msg)
                     else:
                         WarnDialog(msg, title=_('PrivateSend')).open()
 
-    def update_ps_btn(self):
+    def update_ps_btn(self, is_mixing):
         ps_button = self.root.ids.ps_button
-        is_mixing = False
-        wallet = self.wallet
-        if wallet:
-            psman = wallet.psman
-            is_mixing = (psman.state in psman.mixing_running_states)
         if is_mixing:
             ps_button.icon = self.ps_icon(active=True)
         else:

--- a/electrum_dash/gui/kivy/uix/screens.py
+++ b/electrum_dash/gui/kivy/uix/screens.py
@@ -544,6 +544,12 @@ class ReceiveScreen(CScreen):
 
     kvname = 'receive'
 
+    def load_screen(self):
+        super(ReceiveScreen, self).load_screen()
+        psman = self.app.wallet.psman
+        is_mixing = (psman.state in psman.mixing_running_states)
+        self.block_on_mixing(is_mixing)
+
     def update(self):
         if not self.screen.address:
             self.get_new_address()
@@ -563,6 +569,18 @@ class ReceiveScreen(CScreen):
         self.screen.address = ''
         self.screen.amount = ''
         self.screen.message = ''
+
+    def block_on_mixing(self, is_mixing):
+        rcv_main = self.screen.ids.rcv_main
+        rcv_overlap = self.screen.ids.rcv_overlap
+        if is_mixing:
+            rcv_main.opacity = 0
+            rcv_main.disabled = True
+            rcv_overlap.opacity = 1
+        else:
+            rcv_main.opacity = 1
+            rcv_main.disabled = False
+            rcv_overlap.opacity = 0
 
     def get_new_address(self) -> bool:
         """Sets the address field, and returns whether the set address

--- a/electrum_dash/gui/kivy/uix/ui_screens/receive.kv
+++ b/electrum_dash/gui/kivy/uix/ui_screens/receive.kv
@@ -22,7 +22,22 @@ ReceiveScreen:
     on_message:
         self.parent.on_amount_or_message()
 
+    AnchorLayout
+        id: rcv_overlap
+        opacity : 0
+        size_hint: 1, 1
+        anchor_x: 'center'
+        anchor_y: 'center'
+        padding: '24dp', '24dp'
+        Label:
+            text: app.wallet.psman.RECV_BLOCKED_MSG
+            size_hint: 1, None
+            text_size: self.width, None
+            height: self.texture_size[1]
     BoxLayout
+        id: rcv_main
+        disabled: False
+        opacity: 1
         padding: '12dp', '12dp', '12dp', '12dp'
         spacing: '12dp'
         orientation: 'vertical'

--- a/electrum_dash/gui/qt/dark_dash_style.py
+++ b/electrum_dash/gui/qt/dark_dash_style.py
@@ -254,6 +254,16 @@ QLabel {
     margin-top: 0;
 }
 
+#receive_container #roverlap_widget {
+    background-color: #232629;
+}
+
+#receive_container #roverlap_widget QLabel {
+    color: rgb(0, 0, 0);
+    background-color: rgb(248, 240, 200);
+    padding: 20px;
+}
+
 #receive_container > QLabel {
     margin-left:10px;
     min-width:150px;

--- a/electrum_dash/gui/qt/dash_style.py
+++ b/electrum_dash/gui/qt/dash_style.py
@@ -254,6 +254,16 @@ QLabel {
     margin-top: 0;
 }
 
+#receive_container > #roverlap_widget {
+    background:qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(255, 255, 255, 255), stop: 1 rgba(246, 246, 246, 255));
+}
+
+#receive_container #roverlap_widget QLabel {
+    color: rgb(0, 0, 0);
+    background-color: rgb(248, 240, 200);
+    padding: 20px;
+}
+
 #receive_container > QLabel {
     margin-left:10px;
     min-width:150px;

--- a/electrum_dash/json_db.py
+++ b/electrum_dash/json_db.py
@@ -671,7 +671,7 @@ class JsonDB(Logger):
 
     @modifier
     def add_ps_tx(self, txid, tx_type, completed):
-        self.ps_txs[txid] = (tx_type, completed)
+        self.ps_txs[txid] = (int(tx_type), completed)
 
     @modifier
     def pop_ps_tx(self, txid):


### PR DESCRIPTION
- do not run mixing on watching-only wallets with error msg
- qt/kivy block receving GUI when mixing with info msg about cause of block
- fix add_ps_tx (convert tx_type from IntEnum to int before placing to bd to not differ with from file loaded state)