### PR TITLE
PrivateSend allow create small denoms from big one

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,3 +1,15 @@
+# Release 3.3.8.5
+
+ * PrivateSend: Check on small amount of minimal denoms and propose
+   to make new small denoms tx from single larger denom (no change)
+ * PrivateSend: fixes related to keypairs cleanup, fix PS balance when
+   other ps coins is presented
+ * PrivateSEnd: block receiving GUI when mixing to prevent
+   interfering with addresses reserved for PS use
+ * Android: add button to start Orbot on wallet startup if Tor is not
+   detected, fix versionCode for arm64-v8a apk
+
+
 # Release 3.3.8.4
 
  * Trezor/KeepKey plugins: fix signing of CbTx outputs

--- a/electrum_dash/coinchooser.py
+++ b/electrum_dash/coinchooser.py
@@ -581,10 +581,16 @@ class CoinChooserPrivateSend:
             else:
                 break
             selected.append(c)
-        if tx and fee >= estimated_fee:
+
+        fee_overhead = fee - estimated_fee
+        if tx and fee >= estimated_fee and fee_overhead <= PS_DENOMS_VALS[0]:
             return tx
         elif use_repeated_txids and backup_tx:
-            return backup_tx
+            fee = backup_tx.input_value() - spent_amount
+            estimated_fee = fee_estimator_vb(backup_tx.estimated_size())
+            fee_overhead = fee - estimated_fee
+            if fee_overhead <= PS_DENOMS_VALS[0]:
+                return backup_tx
 
 
 COIN_CHOOSERS = {

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -7,7 +7,7 @@ import time
 import threading
 from bls_py import bls
 from enum import IntEnum
-from collections import defaultdict, deque
+from collections import defaultdict, deque, Counter
 from decimal import Decimal
 from math import floor, ceil
 from uuid import uuid4
@@ -123,8 +123,10 @@ PS_DENOM_REVERSE_DICT = {int(v): k for k, v in PS_DENOMS_DICT.items()}
 
 COLLATERAL_VAL = to_duffs(0.0001)
 CREATE_COLLATERAL_VAL = COLLATERAL_VAL*4
-CREATE_COLLATERAL_VALS = [COLLATERAL_VAL*i for i in range(1,10)]
+CREATE_COLLATERAL_VALS = [COLLATERAL_VAL*i for i in range(1,11)]
+MAX_COLLATERAL_VAL = CREATE_COLLATERAL_VALS[-1]
 PS_DENOMS_VALS = sorted(PS_DENOMS_DICT.keys())
+MIN_DENOM_VAL = PS_DENOMS_VALS[0]
 PS_VALS = PS_DENOMS_VALS + CREATE_COLLATERAL_VALS
 
 PS_MIXING_TX_TYPES = list(map(lambda x: x.value, [PSTxTypes.NEW_DENOMS,
@@ -431,6 +433,14 @@ class PSSpendToPSAddressesError(Exception):
 
 class NotFoundInKeypairs(Exception):
     """Thrown when output address not found in keypairs cache"""
+
+
+class TooManyUtxos(Exception):
+    """Thrown when creating new denoms/collateral txs from coins"""
+
+
+class TooLargeUtxoVal(Exception):
+    """Thrown when creating new collateral txs from coins"""
 
 
 class SignWithKeypairsFailed(Exception):
@@ -955,10 +965,11 @@ class PSManager(Logger):
     async def trigger_postponed_notifications(self):
         while True:
             await asyncio.sleep(0.5)
-            for event in list(self.postponed_notifications.keys()):
-                args = self.postponed_notifications.pop(event, None)
-                if args is not None:
-                    self.trigger_callback(event, *args)
+            if self.enabled:
+                for event in list(self.postponed_notifications.keys()):
+                    args = self.postponed_notifications.pop(event, None)
+                    if args is not None:
+                        self.trigger_callback(event, *args)
 
     def on_network_start(self, network):
         self.network = network
@@ -972,6 +983,7 @@ class PSManager(Logger):
         asyncio.ensure_future(self.clean_keypairs_on_timeout())
         asyncio.ensure_future(self.cleanup_staled_denominate_wfls())
         asyncio.ensure_future(self.trigger_postponed_notifications())
+        asyncio.ensure_future(self.broadcast_new_denoms_new_collateral_wfls())
 
     def on_stop_threads(self):
         if self.state == PSStates.Mixing:
@@ -1092,6 +1104,26 @@ class PSManager(Logger):
                      ' of privacy, but also costs more in fees.')
         else:
             return _('PrivateSend rounds to use')
+
+    def create_sm_denoms_data(self, full_txt=False, enough_txt=False,
+                              no_denoms_txt=False, confirm_txt=False):
+        confirm_str_end = _('Do you want to create small denoms from one big'
+                            ' denom utxo? No change value will be created'
+                            ' for privacy reasons.')
+        if full_txt:
+            return _('Create small denominations from big one')
+        elif enough_txt:
+            return '%s %s' % (_('There is enough small denoms.'),
+                              confirm_str_end)
+        elif confirm_txt:
+            return '%s %s' % (_('There is not enough small denoms to make'
+                                ' PrivateSend transactions with reasonable'
+                                ' fees.'),
+                              confirm_str_end)
+        elif no_denoms_txt:
+            return _('There is no denoms to create small denoms from big one.')
+        else:
+            return _('Create small denominations')
 
     @property
     def group_history(self):
@@ -1249,6 +1281,15 @@ class PSManager(Logger):
             self._ps_denoms_amount_cache -= denom[1]
             self._denoms_to_mix_cache.pop(outpoint, None)
         return denom
+
+    def calc_denoms_by_values(self):
+        denoms_values = [denom[1]
+                         for denom in self.wallet.db.get_ps_denoms().values()]
+        if not denoms_values:
+            return {}
+        denoms_by_values = {denom_val: 0 for denom_val in PS_DENOMS_VALS}
+        denoms_by_values.update(Counter(denoms_values))
+        return denoms_by_values
 
     def add_ps_spending_denom(self, outpoint, wfl_uuid):
         self.wallet.db._add_ps_spending_denom(outpoint, wfl_uuid)
@@ -1548,10 +1589,11 @@ class PSManager(Logger):
                     self.logger.info('Cleaned Keyparis Cache')
                     self.keypairs_state = KPStates.Empty
         while True:
-            if (self.state not in self.mixing_running_states
-                    and self.keypairs_state == KPStates.Unused
-                    and self.mix_stop_secs_ago >= self.kp_timeout * 60):
-                await self.loop.run_in_executor(None, _clean_kp_on_timeout)
+            if self.enabled:
+                if (self.state not in self.mixing_running_states
+                        and self.keypairs_state == KPStates.Unused
+                        and self.mix_stop_secs_ago >= self.kp_timeout * 60):
+                    await self.loop.run_in_executor(None, _clean_kp_on_timeout)
             await asyncio.sleep(1)
 
     async def _make_keypairs_cache(self, password):
@@ -1964,6 +2006,30 @@ class PSManager(Logger):
         return tx
 
     # Methods related to mixing process
+    def check_enough_sm_denoms(self, denoms_by_values):
+        if not denoms_by_values:
+            return False
+        for dval in PS_DENOMS_VALS[:-1]:
+            if denoms_by_values[dval] < denoms_by_values[dval*10]:
+                return False
+        return True
+
+    def check_big_denoms_presented(self, denoms_by_values):
+        if not denoms_by_values:
+            return False
+        for dval in PS_DENOMS_VALS[1:]:
+            if denoms_by_values[dval] > 0:
+                return True
+        return False
+
+    def get_biggest_denoms_by_min_round(self):
+        w = self.wallet
+        coins = w.get_utxos(None,
+                            mature_only=True, confirmed_only=True,
+                            consider_islocks=True, min_rounds=0)
+        coins = [c for c in coins if c['value'] > MIN_DENOM_VAL]
+        return sorted(coins, key=lambda x: (x['ps_rounds'], -x['value']))
+
     def check_protx_info_completeness(self):
         if not self.network:
             return False
@@ -2156,6 +2222,21 @@ class PSManager(Logger):
                 await self.prepare_pay_collateral_wfl()
             await asyncio.sleep(0.25)
 
+    async def broadcast_new_denoms_new_collateral_wfls(self):
+        w = self.wallet
+        while True:
+            if self.enabled:
+                wfl = self.new_denoms_wfl
+                if wfl and wfl.completed and wfl.next_to_send(w):
+                    await self.broadcast_new_denoms_wfl()
+                await asyncio.sleep(0.25)
+                wfl = self.new_collateral_wfl
+                if wfl and wfl.completed and wfl.next_to_send(w):
+                    await self.broadcast_new_collateral_wfl()
+                await asyncio.sleep(0.25)
+            else:
+                await asyncio.sleep(1)
+
     async def _maintain_collateral_amount(self):
         kp_wait_state = KPStates.Ready if self.wallet.has_password() else None
 
@@ -2164,8 +2245,6 @@ class PSManager(Logger):
             if wfl:
                 if not wfl.completed or not wfl.tx_order:
                     await self.cleanup_new_collateral_wfl()
-                elif wfl.completed and wfl.next_to_send(self.wallet):
-                    await self.broadcast_new_collateral_wfl()
             elif (not self.ps_collateral_cnt
                     and not self.calc_need_denoms_amounts(use_cache=True)):
                 if kp_wait_state and self.keypairs_state != kp_wait_state:
@@ -2184,8 +2263,6 @@ class PSManager(Logger):
             if wfl:
                 if not wfl.completed or not wfl.tx_order:
                     await self.cleanup_new_denoms_wfl()
-                elif wfl.completed and wfl.next_to_send(self.wallet):
-                    await self.broadcast_new_denoms_wfl()
             elif self.calc_need_denoms_amounts(use_cache=True):
                 if kp_wait_state and self.keypairs_state != kp_wait_state:
                     self.logger.info(f'New denoms workflow waiting'
@@ -2363,7 +2440,7 @@ class PSManager(Logger):
                             mature_only=True)
         coins = [c for c in coins if not w.is_frozen_coin(c)]
         coins_val = sum([c['value'] for c in coins])
-        if coins_val < PS_DENOMS_VALS[0]:  # no coins to create denoms
+        if coins_val < MIN_DENOM_VAL:  # no coins to create denoms
             return []
 
         approx_val = need_val - old_denoms_val
@@ -2381,7 +2458,7 @@ class PSManager(Logger):
                                                       fee_per_kb):
                 return outputs_amounts
             else:
-                approx_val -= PS_DENOMS_VALS[0]
+                approx_val -= MIN_DENOM_VAL
 
     def _calc_total_need_val(self, coins, outputs_amounts, fee_per_kb):
         new_denoms_val = sum([sum(a) for a in outputs_amounts])
@@ -2412,32 +2489,74 @@ class PSManager(Logger):
         return (new_denoms_val + new_denoms_fee +
                 new_collaterals_val + new_collaterals_fee)
 
+    def _calc_denoms_amounts_fee(self, coins_cnt, denoms_amounts, fee_per_kb):
+        txs_fee = 0
+        tx_cnt = len(denoms_amounts)
+        for i in range(tx_cnt):
+            amounts = denoms_amounts[i]
+            if i == 0:
+                # inputs: coins
+                # outputs: denoms + new denom + collateral + change
+                out_cnt = len(amounts) + 3
+                txs_fee += calc_tx_fee(coins_cnt, out_cnt,
+                                       fee_per_kb, max_size=True)
+            elif i == tx_cnt - 1:
+                # inputs: one change amount
+                # outputs: denoms + new denom
+                out_cnt = len(amounts) + 1
+                txs_fee += calc_tx_fee(1, out_cnt,
+                                       fee_per_kb, max_size=True)
+            else:
+                # inputs: one change amount
+                # outputs: is denoms + denom + change
+                out_cnt = len(amounts) + 2
+                txs_fee += calc_tx_fee(1, out_cnt,
+                                       fee_per_kb, max_size=True)
+
+        return txs_fee
+
     def _calc_denoms_amounts_from_coins(self, coins, fee_per_kb):
         coins_val = sum([c['value'] for c in coins])
-        approx_val = coins_val
-        while True:
-            if approx_val < CREATE_COLLATERAL_VAL:
-                return []
-            outputs_amounts = self.find_denoms_approx(approx_val)
-            if not self.ps_collateral_cnt and outputs_amounts:
-                outputs_amounts[0].insert(0, CREATE_COLLATERAL_VAL)
-            new_denoms_val = sum([sum(a) for a in outputs_amounts])
+        coins_cnt = len(coins)
+        denoms_amounts = []
+        denoms_val = 0
+        denoms_cnt = 0
+        approx_found = False
 
-            new_denoms_fee = 0
-            for i, amounts in enumerate(outputs_amounts):
-                if i == 0:  # use all coins as inputs, add change output
-                    new_denoms_fee += calc_tx_fee(len(coins), len(amounts) + 1,
-                                                  fee_per_kb, max_size=True)
-                else:  # use change from prev txs as input
-                    new_denoms_fee += calc_tx_fee(1, len(amounts) + 1,
-                                                  fee_per_kb, max_size=True)
+        while not approx_found:
+            cur_approx_amounts = []
 
-            if coins_val - new_denoms_val - new_denoms_fee > 0:
-                break
-            else:
-                approx_val -= PS_DENOMS_VALS[0] // 2
-
-        return outputs_amounts
+            for dval in PS_DENOMS_VALS:
+                for dn in range(11):  # max 11 values of same denom
+                    all_denoms_amounts = denoms_amounts + [cur_approx_amounts]
+                    txs_fee = self._calc_denoms_amounts_fee(coins_cnt,
+                                                            all_denoms_amounts,
+                                                            fee_per_kb)
+                    min_total = denoms_val + dval + COLLATERAL_VAL + txs_fee
+                    max_total = min_total - COLLATERAL_VAL + MAX_COLLATERAL_VAL
+                    if min_total < coins_val:
+                        denoms_val += dval
+                        denoms_cnt += 1
+                        cur_approx_amounts.append(dval)
+                        if max_total > coins_val:
+                            approx_found = True
+                            break
+                    else:
+                        if dval == MIN_DENOM_VAL:
+                            approx_found = True
+                        break
+                if approx_found:
+                    break
+            if cur_approx_amounts:
+                denoms_amounts.append(cur_approx_amounts)
+        if denoms_amounts:
+            for collateral_val in CREATE_COLLATERAL_VALS[::-1]:
+                if coins_val - denoms_val - collateral_val > txs_fee:
+                    denoms_amounts[0].insert(0, collateral_val)
+                    break
+            real_fee = coins_val - denoms_val - collateral_val
+            assert real_fee - txs_fee < COLLATERAL_VAL, 'too high fee'
+        return denoms_amounts
 
     def find_denoms_approx(self, need_amount):
         if need_amount < COLLATERAL_VAL:
@@ -2453,7 +2572,7 @@ class PSManager(Logger):
             for dval in PS_DENOMS_VALS:
                 for dn in range(11):  # max 11 values of same denom
                     if denoms_total + dval > need_amount:
-                        if dval == PS_DENOMS_VALS[0]:
+                        if dval == MIN_DENOM_VAL:
                             approx_found = True
                             denoms_total += dval
                             cur_approx_amounts.append(dval)
@@ -2481,6 +2600,24 @@ class PSManager(Logger):
             if not w.db.get_ps_spending_denom(outpoint):
                 res.update({outpoint: denom})
         return res
+
+    @property
+    def min_new_denoms_from_coins_val(self):
+        if not self.config:
+            raise Exception('self.config is not set')
+        fee_per_kb = self.config.fee_per_kb()
+        # no change, one coin input, one 100001 out and 10000 collateral out
+        new_denoms_fee = calc_tx_fee(1, 2, fee_per_kb, max_size=True)
+        return new_denoms_fee + MIN_DENOM_VAL + COLLATERAL_VAL
+
+    @property
+    def min_new_collateral_from_coins_val(self):
+        if not self.config:
+            raise Exception('self.config is not set')
+        fee_per_kb = self.config.fee_per_kb()
+        # no change, one coin input, one 10000 output
+        new_collateral_fee = calc_tx_fee(1, 1, fee_per_kb, max_size=True)
+        return new_collateral_fee + COLLATERAL_VAL
 
     # Workflow methods for pay collateral transaction
     def get_confirmed_ps_collateral_data(self):
@@ -2698,6 +2835,29 @@ class PSManager(Logger):
         return tx_data.raw_tx
 
     # Workflow methods for new collateral transaction
+    def new_collateral_from_coins_info(self, coins):
+        if not coins or len(coins) > 1:
+            return
+        coins_val = sum([c['value'] for c in coins])
+        if (coins_val >= self.min_new_denoms_from_coins_val
+                or coins_val < self.min_new_collateral_from_coins_val):
+            return
+        fee_per_kb = self.config.fee_per_kb()
+        for collateral_val in CREATE_COLLATERAL_VALS[::-1]:
+            new_collateral_fee = calc_tx_fee(1, 1, fee_per_kb, max_size=True)
+            if coins_val - new_collateral_fee >= collateral_val:
+                tx_type = SPEC_TX_NAMES[PSTxTypes.NEW_COLLATERAL]
+                info = _('Transactions type: {}').format(tx_type)
+                info += '\n'
+                info += _('Count of transactions: {}').format(1)
+                info += '\n'
+                info += _('Total sent amount: {}').format(coins_val)
+                info += '\n'
+                info += _('Total output amount: {}').format(collateral_val)
+                info += '\n'
+                info += _('Total fee: {}').format(coins_val - collateral_val)
+                return info
+
     def create_new_collateral_wfl_from_gui(self, coins, password):
         if self.state in self.mixing_running_states:
             return None, ('Can not create new collateral as mixing'
@@ -2707,10 +2867,13 @@ class PSManager(Logger):
             return None, ('Can not create new collateral as other new'
                           ' collateral creation process is in progress')
         try:
+            w = self.wallet
             txid, tx = self._make_new_collateral_tx(wfl, coins, password)
-            if not self.wallet.add_transaction(txid, tx):
+            if not w.add_transaction(txid, tx):
                 raise Exception(f'Transaction with txid: {txid}'
                                 f' conflicts with current history')
+            if not w.db.get_ps_tx(txid)[0] == PSTxTypes.NEW_COLLATERAL:
+                self._add_ps_data(txid, tx, PSTxTypes.NEW_COLLATERAL)
             with self.new_collateral_wfl_lock:
                 saved = self.new_collateral_wfl
                 if not saved:
@@ -2732,14 +2895,15 @@ class PSManager(Logger):
                              f' {wfl.lid}')
             return None, err
 
-    async def create_new_collateral_wfl(self):
+    async def create_new_collateral_wfl(self, coins=None):
         _start = self._start_new_collateral_wfl
         wfl = await self.loop.run_in_executor(None, _start)
         if not wfl:
             return
         try:
             _make_tx = self._make_new_collateral_tx
-            txid, tx = await self.loop.run_in_executor(None, _make_tx, wfl)
+            txid, tx = await self.loop.run_in_executor(None, _make_tx,
+                                                       wfl, coins)
             w = self.wallet
             # add_transaction need run in network therad
             if not w.add_transaction(txid, tx):
@@ -2796,21 +2960,9 @@ class PSManager(Logger):
             return self.new_collateral_wfl
 
     def _make_new_collateral_tx(self, wfl, coins=None, password=None):
-        with self.pay_collateral_wfl_lock, \
-                self.new_collateral_wfl_lock, \
-                self.new_denoms_wfl_lock:
-            if self.pay_collateral_wfl:
-                raise Exception('Can not create new collateral as other new'
-                                ' collateral amount seems to exists')
-            if self.new_denoms_wfl:
-                raise Exception('Can not create new collateral as new denoms'
-                                ' creation process is in progress')
+        with self.new_collateral_wfl_lock:
             if self.config is None:
                 raise Exception('self.config is not set')
-
-            if self.ps_collateral_cnt:
-                raise Exception('Can not create new collateral as other new'
-                                ' collateral amount exists')
             saved = self.new_collateral_wfl
             if not saved:
                 raise Exception('new_collateral_wfl not found')
@@ -2819,19 +2971,53 @@ class PSManager(Logger):
 
         # try to create new collateral tx with change outupt at first
         w = self.wallet
+        fee_per_kb = self.config.fee_per_kb()
         uuid = wfl.uuid
         oaddr = self.reserve_addresses(1, data=uuid)[0]
-        outputs = [TxOutput(TYPE_ADDRESS, oaddr, CREATE_COLLATERAL_VAL)]
         if coins is None:
             utxos = w.get_utxos(None,
                                 excluded_addresses=w.frozen_addresses,
                                 mature_only=True, confirmed_only=True,
-                                consider_islocks=True, include_ps=True)
+                                consider_islocks=True)
             utxos = [utxo for utxo in utxos if not w.is_frozen_coin(utxo)]
-            utxos = [utxo for utxo in utxos if utxo['ps_rounds'] is None
-                     or utxo['value'] == PS_DENOMS_VALS[0]]
+            utxos_val = sum([utxo['value'] for utxo in utxos])
+            # try calc fee with change output
+            new_collateral_fee = calc_tx_fee(len(utxos), 2, fee_per_kb,
+                                             max_size=True)
+            if utxos_val - new_collateral_fee < CREATE_COLLATERAL_VAL:
+                # try calc fee without change output
+                new_collateral_fee = calc_tx_fee(len(utxos), 1, fee_per_kb,
+                                                 max_size=True)
+                if utxos_val - new_collateral_fee < CREATE_COLLATERAL_VAL:
+                    # try select minimal denom utxo with mimial rounds
+                    coins = w.get_utxos(None,
+                                        mature_only=True, confirmed_only=True,
+                                        consider_islocks=True, min_rounds=0)
+                    coins = [c for c in coins if c['value'] == MIN_DENOM_VAL]
+                    if not coins:
+                        raise NotEnoughFunds()
+                    coins = sorted(coins, key=lambda x: x['ps_rounds'])
+                    coins = coins[0:1]
+
+        if coins is not None:
+            if len(coins) > 1:
+                raise TooManyUtxos('Not allowed multiple utxos')
+            utxos_val = coins[0]['value']
+            if utxos_val >= self.min_new_denoms_from_coins_val:
+                raise TooLargeUtxoVal('To large utxo selected')
+            outputs = None
+            for collateral_val in CREATE_COLLATERAL_VALS[::-1]:
+                new_collateral_fee = calc_tx_fee(1, 1, fee_per_kb,
+                                                 max_size=True)
+                if utxos_val - new_collateral_fee >= collateral_val:
+                    outputs = [TxOutput(TYPE_ADDRESS, oaddr, collateral_val)]
+                    utxos = coins
+                    break
+            if outputs is None:
+                raise NotEnoughFunds()
         else:
-            utxos = coins
+            outputs = [TxOutput(TYPE_ADDRESS, oaddr, CREATE_COLLATERAL_VAL)]
+
         tx = w.make_unsigned_transaction(utxos, outputs, self.config)
         inputs = tx.inputs()
         # check input addresses is in keypairs if keypairs cache available
@@ -2844,10 +3030,14 @@ class PSManager(Logger):
                                          f' in the keypairs cache:'
                                          f' {not_found_addrs}')
 
-        # use first input address as a change, use selected inputs
-        in0 = inputs[0]['address']
-        tx = w.make_unsigned_transaction(inputs, outputs,
-                                         self.config, change_addr=in0)
+        if coins is not None:  # no change output
+            tx = Transaction.from_io(inputs[:], outputs[:], locktime=0)
+            for txin in tx.inputs():
+                txin['sequence'] = 0xffffffff
+        else:  # use first input address as a change, use selected inputs
+            change_addr = inputs[0]['address']
+            tx = w.make_unsigned_transaction(inputs, outputs, self.config,
+                                             change_addr=change_addr)
         tx = self.sign_transaction(tx, password)
         txid = tx.txid()
         raw_tx = tx.serialize_to_network()
@@ -3004,10 +3194,37 @@ class PSManager(Logger):
                              f' workflow: {wfl.lid}')
 
     # Workflow methods for new denoms transaction
+    def new_denoms_from_coins_info(self, coins):
+        if not coins or len(coins) > 1:
+            return
+        coins_val = sum([c['value'] for c in coins])
+        if coins_val < self.min_new_denoms_from_coins_val:
+            return
+        fee_per_kb = self.config.fee_per_kb()
+        denoms_amounts = self._calc_denoms_amounts_from_coins(coins,
+                                                              fee_per_kb)
+        if denoms_amounts:
+            tx_cnt = len(denoms_amounts)
+            outputs_val = sum([sum(amounts) for amounts in denoms_amounts])
+            tx_type = SPEC_TX_NAMES[PSTxTypes.NEW_DENOMS]
+            info = _('Transactions type: {}').format(tx_type)
+            info += '\n'
+            info += _('Count of transactions: {}').format(tx_cnt)
+            info += '\n'
+            info += _('Total sent amount: {}').format(coins_val)
+            info += '\n'
+            info += _('Total output amount: {}').format(outputs_val)
+            info += '\n'
+            info += _('Total fee: {}').format(coins_val - outputs_val)
+            return info
+
     def create_new_denoms_wfl_from_gui(self, coins, password):
         if self.state in self.mixing_running_states:
             return None, ('Can not create new denoms as mixing process'
                           ' is currently run.')
+        if len(coins) > 1:
+            return None, ('Can not create new denoms,'
+                          ' too many coins selected')
         wfl, outputs_amounts = self._start_new_denoms_wfl(coins)
         if not outputs_amounts:
             return None, ('Can not create new denoms,'
@@ -3019,11 +3236,16 @@ class PSManager(Logger):
         w = self.wallet
         for i, tx_amounts in enumerate(outputs_amounts):
             try:
-                txid, tx = self._make_new_denoms_tx(wfl, tx_amounts, i,
+                txid, tx = self._make_new_denoms_tx(wfl, tx_amounts,
+                                                    last_tx_idx, i,
                                                     coins, password)
                 if not w.add_transaction(txid, tx):
                     raise Exception(f'Transaction with txid: {txid}'
                                     f' conflicts with current history')
+                if not w.db.get_ps_tx(txid)[0] == PSTxTypes.NEW_DENOMS:
+                    self._add_ps_data(txid, tx, PSTxTypes.NEW_DENOMS)
+                self.logger.info(f'Created new denoms tx: {txid},'
+                                 f' workflow: {wfl.lid}')
                 if i == last_tx_idx:
                     with self.new_denoms_wfl_lock:
                         saved = self.new_denoms_wfl
@@ -3038,16 +3260,21 @@ class PSManager(Logger):
                                            f' workflow: {wfl.lid}')
                     return wfl, None
                 else:
-                    prev_outputs = tx.outputs()
-                    c_prev_outputs = len(prev_outputs)
-                    addr = prev_outputs[-1].address
-                    utxos = w.get_utxos([addr], min_rounds=PSCoinRounds.OTHER)
-                    last_outpoint = f'{txid}:{c_prev_outputs-1}'
+                    txin0 = copy.deepcopy(tx.inputs()[0])
+                    w.add_input_info(txin0)
+                    txin0_addr = txin0['address']
+                    utxos = w.get_utxos([txin0_addr],
+                                        min_rounds=PSCoinRounds.OTHER)
+                    change_outpoint = None
+                    for change_idx, o in enumerate(tx.outputs()):
+                        if o.address == txin0_addr:
+                            change_outpoint = f'{txid}:{change_idx}'
+                            break
                     coins = []
                     for utxo in utxos:
                         prev_h = utxo['prevout_hash']
                         prev_n = utxo['prevout_n']
-                        if f'{prev_h}:{prev_n}' != last_outpoint:
+                        if f'{prev_h}:{prev_n}' != change_outpoint:
                             continue
                         coins.append(utxo)
             except Exception as e:
@@ -3070,7 +3297,8 @@ class PSManager(Logger):
                 w = self.wallet
                 _make_tx = self._make_new_denoms_tx
                 txid, tx = await self.loop.run_in_executor(None, _make_tx,
-                                                           wfl, tx_amounts, i)
+                                                           wfl, tx_amounts,
+                                                           last_tx_idx, i)
                 # add_transaction need run in network therad
                 if not w.add_transaction(txid, tx):
                     raise Exception(f'Transaction with txid: {txid}'
@@ -3133,7 +3361,7 @@ class PSManager(Logger):
             self.logger.info(f'Started up new denoms workflow: {wfl.lid}')
             return wfl, outputs_amounts
 
-    def _make_new_denoms_tx(self, wfl, tx_amounts, i,
+    def _make_new_denoms_tx(self, wfl, tx_amounts, last_tx_idx, i,
                             coins=None, password=None):
         if self.config is None:
             raise Exception('self.config is not set')
@@ -3166,9 +3394,14 @@ class PSManager(Logger):
                                          f' in the keypairs cache:'
                                          f' {not_found_addrs}')
 
-        # use first input address as a change, use selected inputs
-        in0 = inputs[0]['address']
-        tx = w.make_unsigned_transaction(inputs, outputs,
+        if coins and i == last_tx_idx:
+            tx = Transaction.from_io(inputs[:], outputs[:], locktime=0)
+            for txin in tx.inputs():
+                txin['sequence'] = 0xffffffff
+        else:
+            # use first input address as a change, use selected inputs
+            in0 = inputs[0]['address']
+            tx = w.make_unsigned_transaction(inputs, outputs,
                                          self.config, change_addr=in0)
         tx = self.sign_transaction(tx, password)
         txid = tx.txid()
@@ -3339,9 +3572,10 @@ class PSManager(Logger):
                     changed = True
             return changed
         while True:
-            changed = await self.loop.run_in_executor(None, _cleanup_staled)
-            if changed:
-                self.wallet.storage.write()
+            if self.enabled:
+                done = await self.loop.run_in_executor(None, _cleanup_staled)
+                if done:
+                    self.wallet.storage.write()
             await asyncio.sleep(WAIT_FOR_MN_TXS_TIME_SEC/12)
 
     async def start_denominate_wfl(self):
@@ -3845,7 +4079,7 @@ class PSManager(Logger):
         dval_cnt = 0
         collateral_cnt = 0
         denoms_cnt = 0
-        last_denom_val = PS_DENOMS_VALS[0]  # must start with minimal denom
+        last_denom_val = MIN_DENOM_VAL  # must start with minimal denom
 
         txin0_addr = inputs[0][0].address
         txin0_tx_type = inputs[0][4]
@@ -4493,6 +4727,23 @@ class PSManager(Logger):
             raise AddPSDataError(f'{txid} unknow type {tx_type}')
         w.db.pop_ps_tx_removed(txid)
         w.db.add_ps_tx(txid, tx_type, completed=True)
+
+        # check if not enough small denoms
+        check_denoms_by_vals = False
+        if tx_type == PSTxTypes.NEW_DENOMS:
+            txin0 = copy.deepcopy(tx.inputs()[0])
+            w.add_input_info(txin0)
+            txin0_addr = txin0['address']
+            if txin0_addr not in [o.address for o in tx.outputs()]:
+                check_denoms_by_vals = True
+        elif tx_type in [PSTxTypes.SPEND_PS_COINS, PSTxTypes.PRIVATESEND]:
+            check_denoms_by_vals = True
+        if check_denoms_by_vals:
+            denoms_by_vals = self.calc_denoms_by_values()
+            if denoms_by_vals:
+                if not self.check_enough_sm_denoms(denoms_by_vals):
+                    self.postpone_notification('ps-not-enough-sm-denoms',
+                                               w, denoms_by_vals)
 
     def _add_tx_ps_data(self, txid, tx):
         '''Used from AddressSynchronizer.add_transaction'''

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -158,6 +158,7 @@ MAX_PRIVATESEND_SESSIONS = 10
 DEFAULT_GROUP_HISTORY = True
 DEFAULT_NOTIFY_PS_TXS = False
 DEFAULT_SUBSCRIBE_SPENT = False
+DEFAULT_ALLOW_OTHERS = False
 
 POOL_MIN_PARTICIPANTS = 3
 POOL_MAX_PARTICIPANTS = 5
@@ -807,6 +808,7 @@ class PSManager(Logger):
         self.wallet_types_supported = ['standard']
         self.keystore_types_supported = ['bip32']
         keystore = wallet.db.get('keystore')
+        self._allow_others = DEFAULT_ALLOW_OTHERS
         if keystore:
             keystore_type = keystore.get('type', 'unknown')
         else:
@@ -1249,6 +1251,44 @@ class PSManager(Logger):
                      ' on electrum servers')
         else:
             return _('Subscribe to spent PS addresses')
+
+    @property
+    def allow_others(self):
+        return self._allow_others
+
+    @allow_others.setter
+    def allow_others(self, allow_others):
+        if self._allow_others == allow_others:
+            return
+        self._allow_others = allow_others
+
+    def allow_others_data(self, full_txt=False,
+                          qt_question=False, kv_question=False):
+        expl = _('Other PS coins appears if some transaction other than'
+                 ' mixing PrivateSend transactions types send funds to one'
+                 ' of addresses used for PrivateSend mixing.\n\nIt is not'
+                 ' recommended for privacy reasons to spend these funds'
+                 ' in regular way. However, you can mix these funds manually'
+                 ' with PrivateSend mixing process.')
+
+        expl2_qt =  _('You can create new denoms or new collateral from other'
+                      ' PS coins on Coins tab. You can also select individual'
+                      ' coin to spend and return to originating address.')
+
+        expl2_kv =  _('You can create new denoms or new collateral from other'
+                      ' PS coins with Coins dialog from PrivateSend options.')
+
+        q = _('This option allow spend other PS coins as a regular coins'
+              ' without coins selection.'
+              ' Are you sure to enable this option?')
+        if full_txt:
+            return _('Allow spend other PS coins in regular transactions')
+        elif qt_question:
+            return '%s\n\n%s\n\n%s' % (expl, expl2_qt, q)
+        elif kv_question:
+            return '%s\n\n%s\n\n%s' % (expl, expl2_kv, q)
+        else:
+            return _('Allow spend other PS coins')
 
     @property
     def ps_collateral_cnt(self):

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -4045,8 +4045,7 @@ class PSManager(Logger):
             return 'Transaction has wrong outputs count'
 
         i, i_prev_h, i_prev_n, is_mine, tx_type = inputs[0]
-        if i.value not in [COLLATERAL_VAL*4,  COLLATERAL_VAL*3,
-                           COLLATERAL_VAL*2, COLLATERAL_VAL]:
+        if i.value not in CREATE_COLLATERAL_VALS:
             return 'Wrong collateral amount'
 
         o, o_prev_h, o_prev_n = outputs[0]
@@ -4054,9 +4053,10 @@ class PSManager(Logger):
             if o.value != 0:
                 return 'Wrong output collateral amount'
         else:
-            if o.value not in [COLLATERAL_VAL*3,  COLLATERAL_VAL*2,
-                               COLLATERAL_VAL]:
+            if o.value not in CREATE_COLLATERAL_VALS[:-1]:
                 return 'Wrong output collateral amount'
+        if o.value != i.value - COLLATERAL_VAL:
+            return 'Wrong output collateral amount'
 
         if not full_check:
             return

--- a/electrum_dash/gui/kivy/uix/dialogs/privatesend.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/privatesend.py
@@ -329,6 +329,12 @@ Builder.load_string('''
                 title: root.subscribe_spent_text + self.value
                 description: root.subscribe_spent_help
                 action: root.toggle_sub_spent
+            CardSeparator
+            SettingsItem:
+                value: ': ON' if root.allow_others else ': OFF'
+                title: root.allow_others_text + self.value
+                description: root.allow_others_help
+                action: root.toggle_allow_others
 
 
 <PSInfoTab@BoxLayout>
@@ -613,6 +619,7 @@ class PSMixingTab(BoxLayout):
     ps_balance = StringProperty()
     group_history = BooleanProperty()
     subscribe_spent = BooleanProperty()
+    allow_others = BooleanProperty()
     is_fiat_dn_balance = False
     is_fiat_ps_balance = False
 
@@ -656,6 +663,9 @@ class PSMixingTab(BoxLayout):
         self.subscribe_spent_text = psman.subscribe_spent_data()
         self.subscribe_spent_help = psman.subscribe_spent_data(full_txt=True)
 
+        self.allow_others_text = psman.allow_others_data()
+        self.allow_others_help = psman.allow_others_data(full_txt=True)
+
         super(PSMixingTab, self).__init__()
         self.update()
 
@@ -676,6 +686,7 @@ class PSMixingTab(BoxLayout):
         self.dn_balance = app.format_amount_and_units(val)
         self.group_history = psman.group_history
         self.subscribe_spent = psman.subscribe_spent
+        self.allow_others = psman.allow_others
 
     def show_warn_electrumx(self, *args):
         EXWarnPopup(self.psman).open()
@@ -784,6 +795,22 @@ class PSMixingTab(BoxLayout):
     def toggle_sub_spent(self, *args):
         self.psman.subscribe_spent = not self.psman.subscribe_spent
         self.subscribe_spent = self.psman.subscribe_spent
+
+    def toggle_allow_others(self, *args):
+        if self.psman.allow_others:
+            self.psman.allow_others = False
+            self.allow_others = False
+        else:
+            q = self.psman.allow_others_data(kv_question=True)
+
+            def on_q_answered(b):
+                if b:
+                    self.psman.allow_others = True
+                    self.allow_others = True
+
+            d = Question(q, on_q_answered)
+            d.size_hint = (0.9, 0.9)
+            d.open()
 
     def show_coins_dialog(self, *args):
         self.app.coins_dialog()

--- a/electrum_dash/gui/kivy/uix/dialogs/privatesend.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/privatesend.py
@@ -299,6 +299,11 @@ Builder.load_string('''
                 action: root.toggle_fiat_dn_balance
             CardSeparator
             SettingsItem:
+                title: root.create_sm_denoms_text
+                description: root.create_sm_denoms_help
+                action: root.create_sm_denoms
+            CardSeparator
+            SettingsItem:
                 title: _('PrivateSend Coins')
                 description: _('Show and use PrivateSend/Standard coins')
                 action: root.show_coins_dialog
@@ -642,6 +647,9 @@ class PSMixingTab(BoxLayout):
         self.dn_balance_text = psman.dn_balance_data()
         self.dn_balance_help = psman.dn_balance_data(full_txt=True)
 
+        self.create_sm_denoms_text = psman.create_sm_denoms_data()
+        self.create_sm_denoms_help = psman.create_sm_denoms_data(full_txt=True)
+
         self.group_history_text = psman.group_history_data()
         self.group_history_help = psman.group_history_data(full_txt=True)
 
@@ -746,6 +754,27 @@ class PSMixingTab(BoxLayout):
     def show_mixing_progress_by_rounds(self, *args):
         d = MixingProgressPopup(self)
         d.open()
+
+    def create_sm_denoms(self, *args):
+        w = self.wallet
+        psman = w.psman
+        denoms_by_vals = psman.calc_denoms_by_values()
+        if (not denoms_by_vals
+                or not psman.check_big_denoms_presented(denoms_by_vals)):
+            msg = psman.create_sm_denoms_data(no_denoms_txt=True)
+            self.app.show_error(msg)
+        else:
+            do_create = False
+            if psman.check_enough_sm_denoms(denoms_by_vals):
+                q = psman.create_sm_denoms_data(enough_txt=True)
+            else:
+                q = psman.create_sm_denoms_data(confirm_txt=True)
+
+            def on_q_answered(b):
+                if b:
+                    self.app.create_small_denoms(denoms_by_vals)
+            d = Question(q, on_q_answered)
+            d.open()
 
     def toggle_group_history(self, *args):
         self.psman.group_history = not self.psman.group_history

--- a/electrum_dash/gui/kivy/uix/screens.py
+++ b/electrum_dash/gui/kivy/uix/screens.py
@@ -531,9 +531,19 @@ class SendScreen(CScreen):
 
     def ps_dialog(self):
         from .dialogs.checkbox_dialog import CheckBoxDialog
+
         def ps_dialog_cb(key):
             self.is_ps = key
+            if self.is_ps:
+                w = self.app.wallet
+                psman = w.psman
+                denoms_by_vals = psman.calc_denoms_by_values()
+                if denoms_by_vals:
+                    if not psman.check_enough_sm_denoms(denoms_by_vals):
+                        psman.postpone_notification('ps-not-enough-sm-denoms',
+                                                     w, denoms_by_vals)
             self.screen.ps_txt = self.privatesend_txt()
+
         d = CheckBoxDialog(_('PrivateSend'),
                            _('Send coins as a PrivateSend transaction'),
                            self.is_ps, ps_dialog_cb)

--- a/electrum_dash/gui/qt/privatesend_dialog.py
+++ b/electrum_dash/gui/qt/privatesend_dialog.py
@@ -480,6 +480,24 @@ class PSDialog(QDialog, MessageBoxMixin):
         i = grid.rowCount()
         grid.addWidget(sub_spent_cb, i, 0, 1, -1)
 
+        # allow_others
+        allow_others_cb = QCheckBox(psman.allow_others_data(full_txt=True))
+        allow_others_cb.setChecked(psman.allow_others)
+
+        def on_allow_others_changed(x):
+            if x == Qt.Checked:
+                q = psman.allow_others_data(qt_question=True)
+                if self.question(q):
+                    psman.allow_others = True
+                else:
+                    allow_others_cb.setCheckState(Qt.Unchecked)
+            else:
+                psman.allow_others = False
+        allow_others_cb.stateChanged.connect(on_allow_others_changed)
+
+        i = grid.rowCount()
+        grid.addWidget(allow_others_cb, i, 0, 1, -1)
+
         # final tab setup
         i = grid.rowCount()
         grid.setRowStretch(i, 1)

--- a/electrum_dash/gui/qt/privatesend_dialog.py
+++ b/electrum_dash/gui/qt/privatesend_dialog.py
@@ -20,6 +20,28 @@ from .util import (HelpLabel, MessageBoxMixin, read_QIcon, custom_message_box,
 ps_dialogs = []  # Otherwise python randomly garbage collects the dialogs
 
 
+def protected_with_parent(func):
+    def request_password(self, *args, **kwargs):
+        mwin = kwargs.pop('mwin')
+        parent = kwargs.pop('parent')
+        password = None
+        while mwin.wallet.has_keystore_encryption():
+            password = mwin.password_dialog(parent=parent)
+            if password is None:
+                # User cancelled password input
+                return
+            try:
+                mwin.wallet.check_password(password)
+                break
+            except Exception as e:
+                mwin.show_error(str(e), parent=parent)
+                continue
+
+        kwargs['password'] = password
+        return func(self, *args, **kwargs)
+    return request_password
+
+
 class FilteredPlainTextEdit(QPlainTextEdit):
 
     def contextMenuEvent(self, event):
@@ -368,6 +390,27 @@ class PSDialog(QDialog, MessageBoxMixin):
         grid.addWidget(dn_balance_label, i, 0)
         grid.addWidget(self.dn_balance_amount, i, 2)
 
+        # create_sm_denoms
+        self.create_sm_denoms_bnt = QPushButton(psman.create_sm_denoms_data())
+
+        def on_create_sm_denoms(x):
+            denoms_by_vals = psman.calc_denoms_by_values()
+            if (not denoms_by_vals
+                    or not psman.check_big_denoms_presented(denoms_by_vals)):
+                msg = psman.create_sm_denoms_data(no_denoms_txt=True)
+                self.show_error(msg)
+            else:
+                if psman.check_enough_sm_denoms(denoms_by_vals):
+                    q = psman.create_sm_denoms_data(enough_txt=True)
+                else:
+                    q = psman.create_sm_denoms_data(confirm_txt=True)
+                if self.question(q):
+                    self.mwin.create_small_denoms(denoms_by_vals, self)
+        self.create_sm_denoms_bnt.clicked.connect(on_create_sm_denoms)
+
+        i = grid.rowCount()
+        grid.addWidget(self.create_sm_denoms_bnt, i, 0, 1, -1)
+
         # max_sessions
         max_sessions_text = psman.max_sessions_data()
         max_sessions_help = psman.max_sessions_data(full_txt=True)
@@ -518,9 +561,11 @@ class PSDialog(QDialog, MessageBoxMixin):
         if psman.state in psman.mixing_running_states:
             self.keep_amount_sb.setEnabled(False)
             self.mix_rounds_sb.setEnabled(False)
+            self.create_sm_denoms_bnt.setEnabled(False)
         else:
             self.keep_amount_sb.setEnabled(True)
             self.mix_rounds_sb.setEnabled(True)
+            self.create_sm_denoms_bnt.setEnabled(True)
         self.mixing_ctl_btn.setText(psman.mixing_control_data())
 
     def update_balances(self):

--- a/electrum_dash/tests/test_dash_ps.py
+++ b/electrum_dash/tests/test_dash_ps.py
@@ -19,7 +19,8 @@ from electrum_dash.dash_ps import (COLLATERAL_VAL, PSPossibleDoubleSpendError,
                                    filter_log_line, KPStates, KP_ALL_TYPES,
                                    KP_SPENDABLE, KP_PS_COINS,
                                    KP_PS_CHANGE, PSStates, calc_tx_size,
-                                   calc_tx_fee, FILTERED_TXID, FILTERED_ADDR)
+                                   calc_tx_fee, FILTERED_TXID, FILTERED_ADDR,
+                                   CREATE_COLLATERAL_VALS)
 from electrum_dash.dash_tx import PSTxTypes, PSCoinRounds, SPEC_TX_NAMES
 from electrum_dash.keystore import xpubkey_to_address
 from electrum_dash.simple_config import SimpleConfig

--- a/electrum_dash/tests/test_dash_ps.py
+++ b/electrum_dash/tests/test_dash_ps.py
@@ -20,7 +20,7 @@ from electrum_dash.dash_ps import (COLLATERAL_VAL, PSPossibleDoubleSpendError,
                                    KP_SPENDABLE, KP_PS_COINS,
                                    KP_PS_CHANGE, PSStates, calc_tx_size,
                                    calc_tx_fee, FILTERED_TXID, FILTERED_ADDR,
-                                   CREATE_COLLATERAL_VALS)
+                                   CREATE_COLLATERAL_VALS, MIN_DENOM_VAL)
 from electrum_dash.dash_tx import PSTxTypes, PSCoinRounds, SPEC_TX_NAMES
 from electrum_dash.keystore import xpubkey_to_address
 from electrum_dash.simple_config import SimpleConfig
@@ -984,29 +984,29 @@ class PSWalletTestCase(TestCaseForTestnet):
         w = self.wallet
         psman = w.psman
         outpoint = '0'*64 + ':0'
-        denom = (w.dummy_address(), 10000, 0)
+        denom = (w.dummy_address(), 100001, 0)
         assert w.db.ps_denoms == {}
         assert psman._ps_denoms_amount_cache == 0
         psman.add_ps_denom(outpoint, denom)
         assert w.db.ps_denoms == {outpoint: denom}
-        assert psman._ps_denoms_amount_cache == 10000
+        assert psman._ps_denoms_amount_cache == 100001
 
     def test_pop_ps_denom(self):
         w = self.wallet
         psman = w.psman
         outpoint1 = '0'*64 + ':0'
         outpoint2 = '1'*64 + ':0'
-        denom1 = (w.dummy_address(), 10000, 0)
-        denom2 = (w.dummy_address(), 40000, 0)
+        denom1 = (w.dummy_address(), 100001, 0)
+        denom2 = (w.dummy_address(), 1000010, 0)
         assert w.db.ps_denoms == {}
         assert psman._ps_denoms_amount_cache == 0
         psman.add_ps_denom(outpoint1, denom1)
         psman.add_ps_denom(outpoint2, denom2)
         assert w.db.ps_denoms == {outpoint1: denom1, outpoint2: denom2}
-        assert psman._ps_denoms_amount_cache == 50000
+        assert psman._ps_denoms_amount_cache == 1100011
         assert denom2 == psman.pop_ps_denom(outpoint2)
         assert w.db.ps_denoms == {outpoint1: denom1}
-        assert psman._ps_denoms_amount_cache == 10000
+        assert psman._ps_denoms_amount_cache == 100001
         assert denom1 == psman.pop_ps_denom(outpoint1)
         assert w.db.ps_denoms == {}
         assert psman._ps_denoms_amount_cache == 0
@@ -1408,34 +1408,14 @@ class PSWalletTestCase(TestCaseForTestnet):
         coro = psman.find_untracked_ps_txs(log=False)
         asyncio.get_event_loop().run_until_complete(coro)
         psman.state = PSStates.Mixing
-        # check not created if ps_collateral is not empty
-        coro = psman.create_new_collateral_wfl()
-        asyncio.get_event_loop().run_until_complete(coro)
-        assert not psman.new_collateral_wfl
-
-        c_outpoint, ps_collateral = w.db.get_ps_collateral()
-        w.db.pop_ps_collateral(c_outpoint)
-        # check not created if pay_collateral_wfl is not empty
-        wfl = PSTxWorkflow(uuid='uuid')
-        psman.set_pay_collateral_wfl(wfl)
-        coro = psman.create_new_collateral_wfl()
-        asyncio.get_event_loop().run_until_complete(coro)
-        assert not psman.new_collateral_wfl
-        psman.clear_pay_collateral_wfl()
 
         # check not created if new_collateral_wfl is not empty
+        wfl = PSTxWorkflow(uuid='uuid')
         psman.set_new_collateral_wfl(wfl)
         coro = psman.create_new_collateral_wfl()
         asyncio.get_event_loop().run_until_complete(coro)
         assert psman.new_collateral_wfl == wfl
         psman.clear_new_collateral_wfl()
-
-        # check not created if new_denoms_wfl is not empty
-        psman.set_new_denoms_wfl(wfl)
-        coro = psman.create_new_collateral_wfl()
-        asyncio.get_event_loop().run_until_complete(coro)
-        assert not psman.new_collateral_wfl
-        psman.clear_new_denoms_wfl()
 
         # check not created if psman.config is not set
         psman.config = None
@@ -1443,14 +1423,6 @@ class PSWalletTestCase(TestCaseForTestnet):
         asyncio.get_event_loop().run_until_complete(coro)
         assert not psman.new_collateral_wfl
         psman.config = self.config
-
-        # check not created as not enough funds
-        old_create_collateral_val = dash_ps.CREATE_COLLATERAL_VAL
-        dash_ps.CREATE_COLLATERAL_VAL = 10000000000  # 100 Dash
-        coro = psman.create_new_collateral_wfl()
-        asyncio.get_event_loop().run_until_complete(coro)
-        assert not psman.new_collateral_wfl
-        dash_ps.CREATE_COLLATERAL_VAL = old_create_collateral_val
 
         # check prepared tx
         coro = psman.create_new_collateral_wfl()
@@ -1469,45 +1441,32 @@ class PSWalletTestCase(TestCaseForTestnet):
         assert txouts[0].value == CREATE_COLLATERAL_VAL
         assert txouts[0].address in w.db.select_ps_reserved(data=wfl.uuid)
 
-    def test_create_new_collateral_wfl_from_ps_denoms(self):
+    def test_create_new_collateral_wfl_from_coins(self):
         w = self.wallet
         psman = w.psman
         psman.config = self.config
 
         coro = psman.find_untracked_ps_txs(log=False)
         asyncio.get_event_loop().run_until_complete(coro)
+        psman.state = PSStates.Mixing
+
         coins = w.get_spendable_coins(domain=None, config=self.config)
-
-        c_outpoint, ps_collateral = w.db.get_ps_collateral()
-        w.db.pop_ps_collateral(c_outpoint)
-        w.db.add_ps_other(c_outpoint, ps_collateral)
-
-        coro = psman.create_new_collateral_wfl()
+        coins = sorted([c for c in coins], key=lambda x: x['value'])
+        # check selected to many utxos
+        coro = psman.create_new_collateral_wfl(coins=coins)
         asyncio.get_event_loop().run_until_complete(coro)
-        assert psman.new_collateral_wfl
+        assert not psman.new_collateral_wfl
+        # check selected to large utxo
+        coro = psman.create_new_collateral_wfl(coins=coins[-1])
+        asyncio.get_event_loop().run_until_complete(coro)
+        assert not psman.new_collateral_wfl
 
-        wfl = psman.new_collateral_wfl
-        txid = wfl.tx_order[0]
-        raw_tx = wfl.tx_data[txid].raw_tx
-        tx = Transaction(raw_tx)
-        for txin in  tx.inputs():
-            ch_tx = w.db.get_transaction(txin['prevout_hash'])
-            prev_n = txin['prevout_n']
-            ch_txout = ch_tx.outputs()[prev_n]
-            assert ch_txout.value not in PS_DENOMS_VALS
-        psman.clear_new_collateral_wfl()
-
-        for c in coins:
-            prev_h = c['prevout_hash']
-            prev_n = c['prevout_n']
-            c_outpoint = f'{prev_h}:{prev_n}'
-            c_other = (c['address'], c['value'])
-            w.db.add_ps_other(c_outpoint, c_other)
-
+        w.set_frozen_state_of_coins(coins, True)
         coins = w.get_spendable_coins(domain=None, include_ps=False,
                                       config=self.config)
         assert coins == []
 
+        # check created from minimal denom value
         coro = psman.create_new_collateral_wfl()
         asyncio.get_event_loop().run_until_complete(coro)
         assert psman.new_collateral_wfl
@@ -1515,11 +1474,99 @@ class PSWalletTestCase(TestCaseForTestnet):
         txid = wfl.tx_order[0]
         raw_tx = wfl.tx_data[txid].raw_tx
         tx = Transaction(raw_tx)
-        for txin in  tx.inputs():
-            ch_tx = w.db.get_transaction(txin['prevout_hash'])
-            prev_n = txin['prevout_n']
-            ch_txout = ch_tx.outputs()[prev_n]
-            assert ch_txout.value == PS_DENOMS_VALS[0]
+        inputs = tx.inputs()
+        outputs = tx.outputs()
+        assert len(inputs) == 1
+        assert len(outputs) == 1  # no change
+        txin = inputs[0]
+        prev_h = txin['prevout_hash']
+        prev_n = txin['prevout_n']
+        prev_tx = w.db.get_transaction(prev_h)
+        prev_txout = prev_tx.outputs()[prev_n]
+        assert prev_txout.value == MIN_DENOM_VAL
+        assert outputs[0].value == CREATE_COLLATERAL_VALS[-2]  # 90000
+
+        # check denom is spent
+        denom_oupoint = f'{prev_h}:{prev_n}'
+        assert not w.db.get_ps_denom(denom_oupoint)
+        assert w.db.get_ps_spent_denom(denom_oupoint)[1] == MIN_DENOM_VAL
+
+        assert psman.new_collateral_wfl
+        for txid in wfl.tx_order:
+            tx = Transaction(wfl.tx_data[txid].raw_tx)
+            psman._process_by_new_collateral_wfl(txid, tx)
+        assert not psman.new_collateral_wfl
+
+    def test_create_new_collateral_wfl_from_gui(self):
+        w = self.wallet
+        psman = w.psman
+        psman.config = self.config
+
+        coro = psman.find_untracked_ps_txs(log=False)
+        asyncio.get_event_loop().run_until_complete(coro)
+
+        coins = w.get_spendable_coins(domain=None, config=self.config)
+        coins = sorted([c for c in coins], key=lambda x: x['value'])
+        # check selected to many utxos
+        assert not psman.new_collateral_from_coins_info(coins)
+        wfl, err = psman.create_new_collateral_wfl_from_gui(coins, None)
+        assert err
+        assert not wfl
+
+        # check selected to large utxo
+        assert not psman.new_collateral_from_coins_info(coins[-1])
+        wfl, err = psman.create_new_collateral_wfl_from_gui(coins, None)
+        assert err
+        assert not wfl
+
+        # check on single minimal denom
+        coins = w.get_utxos(None, mature_only=True, confirmed_only=True,
+                            consider_islocks=True, min_rounds=0)
+        coins = [c for c in coins if c['value'] == MIN_DENOM_VAL]
+        coins = sorted(coins, key=lambda x: x['ps_rounds'])
+        coins = coins[0:1]
+        assert psman.new_collateral_from_coins_info(coins) == \
+            ('Transactions type: PS New Collateral\n'
+             'Count of transactions: 1\n'
+             'Total sent amount: 100001\n'
+             'Total output amount: 90000\n'
+             'Total fee: 10001')
+
+        # check not created if mixing
+        psman.state = PSStates.Mixing
+        wfl, err = psman.create_new_collateral_wfl_from_gui(coins, None)
+        assert err
+        assert not wfl
+        psman.state = PSStates.Ready
+
+        # check created on minimal denom
+        wfl, err = psman.create_new_collateral_wfl_from_gui(coins, None)
+        assert not err
+        txid = wfl.tx_order[0]
+        raw_tx = wfl.tx_data[txid].raw_tx
+        tx = Transaction(raw_tx)
+        inputs = tx.inputs()
+        outputs = tx.outputs()
+        assert len(inputs) == 1
+        assert len(outputs) == 1  # no change
+        txin = inputs[0]
+        prev_h = txin['prevout_hash']
+        prev_n = txin['prevout_n']
+        prev_tx = w.db.get_transaction(prev_h)
+        prev_txout = prev_tx.outputs()[prev_n]
+        assert prev_txout.value == MIN_DENOM_VAL
+        assert outputs[0].value == CREATE_COLLATERAL_VALS[-2]  # 90000
+
+        # check denom is spent
+        denom_oupoint = f'{prev_h}:{prev_n}'
+        assert not w.db.get_ps_denom(denom_oupoint)
+        assert w.db.get_ps_spent_denom(denom_oupoint)[1] == MIN_DENOM_VAL
+
+        assert psman.new_collateral_wfl
+        for txid in wfl.tx_order:
+            tx = Transaction(wfl.tx_data[txid].raw_tx)
+            psman._process_by_new_collateral_wfl(txid, tx)
+        assert not psman.new_collateral_wfl
 
     def test_cleanup_new_collateral_wfl(self):
         w = self.wallet
@@ -1707,7 +1754,7 @@ class PSWalletTestCase(TestCaseForTestnet):
         c01 = list(filter(lambda x: x['value'] == dv01, coins))
         c1 = list(filter(lambda x: x['value'] == dv1, coins))
         other = list(filter(lambda x: x['value'] not in PS_DENOMS_VALS, coins))
-        ccv = CREATE_COLLATERAL_VAL
+        ccv = COLLATERAL_VAL*9
         assert len(c1) == 2
         assert len(c01) == 26
         assert len(c001) == 33
@@ -1807,8 +1854,8 @@ class PSWalletTestCase(TestCaseForTestnet):
                     [dv0001]*11 + [dv001]*4, [dv0001]*6]
         assert psman.calc_need_denoms_amounts(coins=c1[0:2]) == expected
 
-        expected = [[ccv] + [dv0001]*11 + [dv001]*11 + [dv01]*11 + [dv1]*8,
-                    [dv0001]*11 + [dv001]*11 + [dv01]*5, [dv0001]*5]
+        expected = [[10000] + [dv0001]*11 + [dv001]*11 + [dv01]*11 + [dv1]*8,
+                    [dv0001]*11 + [dv001]*11 + [dv01]*5, [dv0001]*6]
         assert psman.calc_need_denoms_amounts(coins=other) == expected
 
     def test_calc_tx_size(self):
@@ -1980,10 +2027,174 @@ class PSWalletTestCase(TestCaseForTestnet):
         c, u, x = w.get_balance(include_ps=False)
         new_collateral_cnt = 19
         new_collateral_fee = calc_tx_fee(1, 2, fee_per_kb, max_size=True)
-        half_minimal_denom = PS_DENOMS_VALS[0] // 2
+        half_minimal_denom = MIN_DENOM_VAL // 2
         assert (c + u -
                 CREATE_COLLATERAL_VAL * new_collateral_cnt -
                 new_collateral_fee * new_collateral_cnt) < half_minimal_denom
+
+    def test_create_new_denoms_wfl_from_gui(self):
+        w = self.wallet
+        psman = w.psman
+        psman.config = self.config
+
+        coro = psman.find_untracked_ps_txs(log=False)
+        asyncio.get_event_loop().run_until_complete(coro)
+
+        coins = w.get_spendable_coins(domain=None, config=self.config)
+        coins = sorted([c for c in coins], key=lambda x: x['value'])
+        # check selected to many utxos
+        assert not psman.new_denoms_from_coins_info(coins)
+        wfl, err = psman.create_new_denoms_wfl_from_gui(coins, None)
+        assert err
+        assert not wfl
+
+        coins = w.get_utxos(None, mature_only=True, confirmed_only=True,
+                            consider_islocks=True, min_rounds=0)
+        coins = [c for c in coins if c['value'] == PS_DENOMS_VALS[-2]]
+        coins = sorted(coins, key=lambda x: x['ps_rounds'])
+
+        # check on single max value available denom
+        coins = coins[0:1]
+
+        # check not created if mixing
+        psman.state = PSStates.Mixing
+        wfl, err = psman.create_new_denoms_wfl_from_gui(coins, None)
+        assert err
+        assert not wfl
+        psman.state = PSStates.Ready
+
+        # check on 100001000 denom
+        assert psman.new_denoms_from_coins_info(coins) == \
+            ('Transactions type: PS New Denoms\n'
+             'Count of transactions: 3\n'
+             'Total sent amount: 100001000\n'
+             'Total output amount: 99990999\n'
+             'Total fee: 10001')
+
+        wfl, err = psman.create_new_denoms_wfl_from_gui(coins, None)
+        assert not err
+        txid = wfl.tx_order[0]
+        raw_tx = wfl.tx_data[txid].raw_tx
+        tx = Transaction(raw_tx)
+        inputs = tx.inputs()
+        outputs = tx.outputs()
+        assert len(inputs) == 1
+        assert len(outputs) == 32
+        txin = inputs[0]
+        prev_h = txin['prevout_hash']
+        prev_n = txin['prevout_n']
+        prev_tx = w.db.get_transaction(prev_h)
+        prev_txout = prev_tx.outputs()[prev_n]
+        assert prev_txout.value == PS_DENOMS_VALS[-2]
+        assert outputs[0].value == CREATE_COLLATERAL_VALS[-2]  # 90000
+        total_out_vals = 0
+        out_vals = [o.value for o in outputs]
+        total_out_vals += sum(out_vals) - 7808833
+        assert out_vals == [90000, 100001, 100001, 100001, 100001, 100001,
+                            100001, 100001, 100001, 100001, 100001, 100001,
+                            1000010, 1000010, 1000010, 1000010, 1000010,
+                            1000010, 1000010, 1000010, 1000010, 1000010,
+                            1000010, 7808833, 10000100, 10000100, 10000100,
+                            10000100, 10000100, 10000100, 10000100, 10000100]
+
+        txid = wfl.tx_order[1]
+        raw_tx = wfl.tx_data[txid].raw_tx
+        tx = Transaction(raw_tx)
+        inputs = tx.inputs()
+        outputs = tx.outputs()
+        out_vals = [o.value for o in outputs]
+        total_out_vals += sum(out_vals) - 707992
+        assert out_vals == [100001, 100001, 100001, 100001, 100001, 100001,
+                            100001, 100001, 100001, 100001, 100001, 707992,
+                            1000010, 1000010, 1000010, 1000010, 1000010,
+                            1000010]
+
+        txid = wfl.tx_order[2]
+        raw_tx = wfl.tx_data[txid].raw_tx
+        tx = Transaction(raw_tx)
+        inputs = tx.inputs()
+        outputs = tx.outputs()
+        out_vals = [o.value for o in outputs]
+        total_out_vals += sum(out_vals)
+        assert out_vals == [100001, 100001, 100001, 100001, 100001, 100001,
+                            100001]
+        assert total_out_vals == 99990999
+
+        # check denom is spent
+        denom_oupoint = f'{prev_h}:{prev_n}'
+        assert not w.db.get_ps_denom(denom_oupoint)
+        assert w.db.get_ps_spent_denom(denom_oupoint)[1] == PS_DENOMS_VALS[-2]
+
+        # process
+        for txid in wfl.tx_order:
+            tx = Transaction(wfl.tx_data[txid].raw_tx)
+            psman._process_by_new_denoms_wfl(txid, tx)
+        assert not psman.new_denoms_wfl
+
+        # check on 10000100 denom
+        total_out_vals = 0
+        coins = w.get_utxos(None, mature_only=True, confirmed_only=True,
+                            consider_islocks=True, min_rounds=0)
+        coins = [c for c in coins if c['value'] == PS_DENOMS_VALS[-3]]
+        coins = sorted(coins, key=lambda x: x['ps_rounds'])
+        coins = coins[0:1]
+        assert psman.new_denoms_from_coins_info(coins) == \
+            ('Transactions type: PS New Denoms\n'
+             'Count of transactions: 2\n'
+             'Total sent amount: 10000100\n'
+             'Total output amount: 9990099\n'
+             'Total fee: 10001')
+        wfl, err = psman.create_new_denoms_wfl_from_gui(coins, None)
+        txid = wfl.tx_order[0]
+        raw_tx = wfl.tx_data[txid].raw_tx
+        tx = Transaction(raw_tx)
+        out_vals = [o.value for o in tx.outputs()]
+        total_out_vals += sum(out_vals) - 809137
+        assert out_vals == [90000, 100001, 100001, 100001, 100001, 100001,
+                            100001, 100001, 100001, 100001, 100001, 100001,
+                            809137, 1000010, 1000010, 1000010, 1000010,
+                            1000010, 1000010, 1000010, 1000010]
+        txid = wfl.tx_order[1]
+        raw_tx = wfl.tx_data[txid].raw_tx
+        tx = Transaction(raw_tx)
+        out_vals = [o.value for o in tx.outputs()]
+        total_out_vals += sum(out_vals)
+        assert out_vals == [100001, 100001, 100001, 100001, 100001, 100001,
+                            100001, 100001]
+        assert total_out_vals == 9990099
+        # process
+        for txid in wfl.tx_order:
+            tx = Transaction(wfl.tx_data[txid].raw_tx)
+            psman._process_by_new_denoms_wfl(txid, tx)
+        assert not psman.new_denoms_wfl
+
+        # check on 1000010 denom
+        total_out_vals = 0
+        coins = w.get_utxos(None, mature_only=True, confirmed_only=True,
+                            consider_islocks=True, min_rounds=0)
+        coins = [c for c in coins if c['value'] == PS_DENOMS_VALS[-4]]
+        coins = sorted(coins, key=lambda x: x['ps_rounds'])
+        coins = coins[0:1]
+        assert psman.new_denoms_from_coins_info(coins) == \
+            ('Transactions type: PS New Denoms\n'
+             'Count of transactions: 1\n'
+             'Total sent amount: 1000010\n'
+             'Total output amount: 990009\n'
+             'Total fee: 10001')
+        wfl, err = psman.create_new_denoms_wfl_from_gui(coins, None)
+        txid = wfl.tx_order[0]
+        raw_tx = wfl.tx_data[txid].raw_tx
+        tx = Transaction(raw_tx)
+        out_vals = [o.value for o in tx.outputs()]
+        total_out_vals += sum(out_vals)
+        assert out_vals == [90000, 100001, 100001, 100001, 100001, 100001,
+                            100001, 100001, 100001, 100001]
+        assert total_out_vals == 990009
+        # process
+        for txid in wfl.tx_order:
+            tx = Transaction(wfl.tx_data[txid].raw_tx)
+            psman._process_by_new_denoms_wfl(txid, tx)
+        assert not psman.new_denoms_wfl
 
     def test_cleanup_new_denoms_wfl(self):
         w = self.wallet
@@ -2832,3 +3043,104 @@ class PSWalletTestCase(TestCaseForTestnet):
 
         for addr in not_in_wallet_change_addrs:
             assert psman._is_mine_slow(addr, for_change=True)
+
+    def test_calc_denoms_by_values(self):
+        w = self.wallet
+        psman = w.psman
+        psman.config = self.config
+
+        null_vals = {100001: 0, 1000010: 0, 10000100: 0,
+                     100001000: 0, 1000010000: 0}
+        assert psman.calc_denoms_by_values() == {}
+
+        coro = psman.find_untracked_ps_txs(log=False)
+        asyncio.get_event_loop().run_until_complete(coro)
+
+        found_vals = {100001: 70, 1000010: 33, 10000100: 26,
+                      100001000: 2, 1000010000: 0}
+        assert psman.calc_denoms_by_values() == found_vals
+
+    def test_min_new_denoms_from_coins_val(self):
+        w = self.wallet
+        psman = w.psman
+
+        with self.assertRaises(Exception):
+            psman.min_new_denoms_from_coins_val
+
+        psman.config = self.config
+        assert psman.min_new_denoms_from_coins_val == 110228
+
+    def test_min_new_collateral_from_coins_val(self):
+        w = self.wallet
+        psman = w.psman
+
+        with self.assertRaises(Exception):
+            psman.min_new_collateral_from_coins_val
+
+        psman.config = self.config
+        assert psman.min_new_collateral_from_coins_val == 10193
+
+    def test_check_enough_sm_denoms(self):
+        w = self.wallet
+        psman = w.psman
+        psman.config = self.config
+
+        denoms_by_vals = {}
+        assert not psman.check_enough_sm_denoms(denoms_by_vals)
+
+        denoms_by_vals = {100001: 5, 1000010: 0,
+                          10000100: 5, 100001000: 0, 1000010000: 0}
+        assert not psman.check_enough_sm_denoms(denoms_by_vals)
+
+        denoms_by_vals = {100001: 4, 1000010: 5,
+                          10000100: 0, 100001000: 0, 1000010000: 0}
+        assert not psman.check_enough_sm_denoms(denoms_by_vals)
+
+        denoms_by_vals = {100001: 5, 1000010: 5,
+                          10000100: 0, 100001000: 0, 1000010000: 0}
+        assert psman.check_enough_sm_denoms(denoms_by_vals)
+
+        denoms_by_vals = {100001: 25, 1000010: 25,
+                          10000100: 2, 100001000: 0, 1000010000: 0}
+        assert psman.check_enough_sm_denoms(denoms_by_vals)
+
+    def test_check_big_denoms_presented(self):
+        w = self.wallet
+        psman = w.psman
+        psman.config = self.config
+
+        denoms_by_vals = {}
+        assert not psman.check_big_denoms_presented(denoms_by_vals)
+
+        denoms_by_vals = {100001: 1, 1000010: 0,
+                          10000100: 0, 100001000: 0, 1000010000: 0}
+        assert not psman.check_big_denoms_presented(denoms_by_vals)
+
+        denoms_by_vals = {100001: 0, 1000010: 1,
+                          10000100: 0, 100001000: 0, 1000010000: 0}
+        assert psman.check_big_denoms_presented(denoms_by_vals)
+
+        denoms_by_vals = {100001: 0, 1000010: 0,
+                          10000100: 1, 100001000: 0, 1000010000: 0}
+        assert psman.check_big_denoms_presented(denoms_by_vals)
+
+        denoms_by_vals = {100001: 0, 1000010: 0,
+                          10000100: 1, 100001000: 0, 1000010000: 1}
+        assert psman.check_big_denoms_presented(denoms_by_vals)
+
+    def test_get_biggest_denoms_by_min_round(self):
+        w = self.wallet
+        psman = w.psman
+        psman.config = self.config
+
+        assert psman.get_biggest_denoms_by_min_round() == []
+
+        coro = psman.find_untracked_ps_txs(log=False)
+        asyncio.get_event_loop().run_until_complete(coro)
+
+        coins = psman.get_biggest_denoms_by_min_round()
+        res_r = [c['ps_rounds'] for c in coins]
+        res_v = [c['value'] for c in coins]
+        assert res_r == [0] * 22 + [2] * 39
+        assert res_v == ([10000100] * 10 + [1000010] * 12 + [100001000] * 2 +
+                         [10000100] * 16 + [1000010] * 21)

--- a/electrum_dash/version.py
+++ b/electrum_dash/version.py
@@ -1,8 +1,8 @@
 import re
 
 
-ELECTRUM_VERSION = '3.3.8.4' # version of the client package
-APK_VERSION = '3.3.8.4'      # read by buildozer.spec
+ELECTRUM_VERSION = '3.3.8.5' # version of the client package
+APK_VERSION = '3.3.8.5'      # read by buildozer.spec
 
 PROTOCOL_VERSION = '1.4.2'   # protocol version requested
 

--- a/electrum_dash/wallet.py
+++ b/electrum_dash/wallet.py
@@ -50,7 +50,7 @@ from .bitcoin import (COIN, TYPE_ADDRESS, is_address, address_to_script,
                       is_minikey, relayfee, dust_threshold, public_key_to_p2pkh)
 from .crypto import sha256d
 from . import keystore
-from .dash_tx import SPEC_TX_NAMES
+from .dash_tx import SPEC_TX_NAMES, PSCoinRounds
 from .keystore import load_keystore, Hardware_KeyStore
 from .util import multisig_type
 from .storage import STO_EV_PLAINTEXT, STO_EV_USER_PW, STO_EV_XPUB_PW, WalletStorage
@@ -462,6 +462,9 @@ class Abstract_Wallet(AddressSynchronizer):
                                include_ps=include_ps,
                                min_rounds=min_rounds)
         utxos = [utxo for utxo in utxos if not self.is_frozen_coin(utxo)]
+        if self.psman.enabled and include_ps and not self.psman.allow_others:
+            utxos = [utxo for utxo in utxos
+                     if utxo['ps_rounds'] != PSCoinRounds.OTHER]
         return utxos
 
     def get_receiving_addresses(self, *, slice_start=None, slice_stop=None) -> Sequence:


### PR DESCRIPTION
- modify check/add/rm for new denoms/collateral (allow collateral val 10000-100000 in some cases)
- modify _check_pay_collateral_tx_err (allow collateral val 10000-100000)
- psman: modify new denoms/collateral wfl behaviour (allow creating collateral, denoms from gui from singl other ps coin or from single denom withot change, create new denoms from minimal denoms without change with val 90000 if no funds in regular balance left)

p.s.:
- limit fee_overhead to minimal denom in PS coinchooser
- add allow_others option, test, qt/kivy gui