### PR TITLE
Extend ProRegTx usage (allow creation of collateral in ProRegTx)

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -3,6 +3,9 @@
  * PrivateSend: allow start mixing before llmq/protx ready,
    stop mixing only if keep amount is available on ps balance
  * Enhance "Detect Tor proxy on wallet startup" option behaviour/UI
+ * DIP3 masternodes: support collateral in ProRegTx output (p2sh addresses
+   support), other fixes
+ * Remove legacy masternodes commands from commands.py
  * Add UI to handle Other PS coins
  * Other PS fixes
 

--- a/electrum_dash/commands.py
+++ b/electrum_dash/commands.py
@@ -46,9 +46,6 @@ from .paymentrequest import PR_PAID, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED
 from .synchronizer import Notifier
 from .wallet import Abstract_Wallet, create_new_wallet, restore_wallet_from_text
 from .address_synchronizer import TX_HEIGHT_LOCAL
-from .masternode import MasternodeAnnounce
-from .masternode_budget import BudgetProposal
-from .masternode_manager import MasternodeManager, parse_masternode_conf, BUDGET_FEE_CONFIRMATIONS
 from .version import is_release
 
 if TYPE_CHECKING:
@@ -110,10 +107,6 @@ class Commands:
         self.config = config
         self.wallet = wallet
         self.network = network
-        self.masternode_manager = None
-        if self.wallet:
-            self.masternode_manager = MasternodeManager(self.wallet,
-                                                        self.config)
         self._callback = callback
 
     def _run(self, method, args, password_getter):
@@ -708,184 +701,6 @@ class Commands:
         for k in list(self.wallet.receive_requests.keys()):
             self.wallet.remove_payment_request(k, self.config)
 
-    # Masternode commands.
-    @command('wnp')
-    def importmasternodeconf(self, conf_file):
-        """Import a masternode.conf file."""
-        if not os.path.exists(conf_file):
-            return 'File does not exist.'
-        with open(conf_file, 'r') as f:
-            lines = f.readlines()
-
-        try:
-            conf_lines = parse_masternode_conf(lines)
-        except Exception as e:
-            return 'Error parsing: ' + str(e)
-
-        mn_man = self.masternode_manager
-        num = mn_man.import_masternode_conf_lines(conf_lines, self.password)
-        if not num:
-            return 'Could not import any configurations. Please ensure that they are not already imported.'
-        return '%d configuration%s imported.' % (num, 's' if num == 1 else '')
-
-    @command('w')
-    def newmasternode(self, alias):
-        """Create a new masternode."""
-        try:
-            self.masternode_manager.add_masternode(MasternodeAnnounce(alias=alias))
-            return 'Added new masternode "%s".' % alias
-        except Exception as e:
-            return 'Error: %s' % str(e)
-
-    @command('w')
-    def rmmasternode(self, alias):
-        """Remove an existing masternode."""
-        try:
-            self.masternode_manager.remove_masternode(alias)
-            return 'Removed masternode "%s".' % alias
-        except Exception as e:
-            return 'Error: %s' % str(e)
-
-    @command('w')
-    def listmasternodes(self):
-        """List wallet masternodes."""
-        return sorted([i.alias for i in self.masternode_manager.masternodes])
-
-    @command('w')
-    def showmasternode(self, alias):
-        """Show details about a masternode."""
-        mn = self.masternode_manager.get_masternode(alias)
-        if not mn:
-            return 'No masternode exists for alias "%s".' % alias
-        return mn.dump()
-
-    @command('w')
-    def listmasternodepayments(self):
-        """List unused masternode-compatible payments."""
-        return self.masternode_manager.get_masternode_outputs(exclude_frozen=False)
-
-    @command('wnp')
-    def activatemasternode(self, alias):
-        """Activate a masternode."""
-        self.masternode_manager.populate_masternode_output(alias)
-        try:
-            self.masternode_manager.sign_announce(alias, self.password)
-        except Exception as e:
-            return 'Error signing: ' + str(e)
-
-        try:
-            self.masternode_manager.send_announce(alias)
-        except Exception as e:
-            return 'Error sending: ' + str(e)
-
-        return 'Masternode "%s" activated successfully.' % alias
-
-    # Budget-related commands.
-    @command('wp')
-    def prepareproposal(self, proposal_name, proposal_url, payments_count, block_start, address, amount, broadcast=False):
-        """Create a budget proposal transaction."""
-        proposal = self.masternode_manager.get_proposal(proposal_name)
-        amount = int(amount*COIN)
-        if not proposal:
-            proposal = BudgetProposal(proposal_name=proposal_name, proposal_url=proposal_url, start_block=block_start,
-                        payment_amount=amount, address=address)
-            proposal.set_payments_count(payments_count)
-            self.masternode_manager.add_proposal(proposal)
-
-        tx = self.masternode_manager.create_proposal_tx(proposal_name, self.password)
-
-        if broadcast:
-            r, h = self.wallet.sendtx(tx)
-            return h
-        return str(tx)
-
-    @command('wn')
-    def sendproposal(self, proposal_name):
-        """Send a budget proposal."""
-        try:
-            errmsg, submitted = self.masternode_manager.submit_proposal(proposal_name)
-        except Exception as e:
-            return 'Error: %s' % str(e)
-
-        if errmsg:
-            return 'Error: %s' % errmsg
-        return submitted
-
-    @command('wn')
-    def sendreadyproposals(self):
-        """Send all budget proposals that are ready to be sent."""
-        results = {}
-        proposals = filter(lambda p: p.fee_txid and not p.submitted and not p.rejected, self.masternode_manager.proposals)
-        for p in proposals:
-            tx_height = self.wallet.get_tx_height(p.fee_txid)
-            if tx_height.conf < BUDGET_FEE_CONFIRMATIONS:
-                continue
-
-            errmsg, success = self.masternode_manager.submit_proposal(p.proposal_name)
-            if not success:
-                results[p.proposal_name] = errmsg
-            else:
-                results[p.proposal_name] = 'Successfully submitted'
-
-        return results
-
-    @command('w')
-    def listproposals(self):
-        """List proposals created with this wallet."""
-        return {p.proposal_name: p.dump() for p in self.masternode_manager.proposals}
-
-    @command('w')
-    def listreadyproposals(self):
-        """List the proposals created with this wallet that are ready to be submitted."""
-        results = {}
-        proposals = filter(lambda p: p.fee_txid and not p.submitted and not p.rejected, self.masternode_manager.proposals)
-        for p in proposals:
-            tx_height = self.wallet.get_tx_height(p.fee_txid)
-            if tx_height.conf < BUDGET_FEE_CONFIRMATIONS:
-                continue
-            results[p.proposal_name] = p.dump()
-
-        return results
-
-    @command('n')
-    def mnbudget(self, budget_command):
-        """Get information on masternode budget proposals."""
-        valid_commands = ('list', 'nextblock', 'nextsuperblocksize', 'projection')
-        if budget_command not in valid_commands:
-            return 'Budget command must be one of %s' % valid_commands
-        method = 'masternode.budget.%s' % budget_command
-        return self.network.synchronous_get([(method, [])])[0]
-
-    @command('n')
-    def getvotes(self, proposal_hash):
-        """Get the votes for a budget proposal."""
-        req = ('masternode.budget.getvotes', [proposal_hash])
-        return self.network.synchronous_get([req])[0]
-
-    @command('n')
-    def getproposalhash(self, proposal_name):
-        """Get the hash of a budget proposal by its name."""
-        req = ('masternode.budget.getproposalhash', [proposal_name])
-        return self.network.synchronous_get([req])[0]
-
-    @command('n')
-    def getproposal(self, proposal_hash):
-        """Get information on a budget proposal."""
-        req = ('masternode.budget.getproposal', [proposal_hash])
-        return self.network.synchronous_get([req])[0]
-
-    @command('wn')
-    def vote(self, alias, proposal_name, vote_choice):
-        """Vote on a proposal."""
-        valid_choices = ('yes', 'no')
-        if vote_choice.lower() not in valid_choices:
-            return 'Invalid vote choice: "%s"' % vote_choice
-
-        errmsg, success = self.masternode_manager.vote(alias, proposal_name, vote_choice)
-        if errmsg:
-            return 'Error: %s' % errmsg
-        return success
-
     @command('n')
     def notify(self, address: str, URL: str):
         """Watch an address. Every time the address changes, a http POST is sent to the URL."""
@@ -990,8 +805,6 @@ param_descriptions = {
     'requested_amount': 'Requested amount (in DASH).',
     'outputs': 'list of ["address", amount]',
     'redeem_script': 'redeem script (hexadecimal)',
-    'conf_file': 'Masternode.conf file from Dash.',
-    'alias': 'Masternode alias.',
     'cpfile': 'Checkpoints file',
 }
 

--- a/electrum_dash/gui/qt/dash_qt.py
+++ b/electrum_dash/gui/qt/dash_qt.py
@@ -151,20 +151,28 @@ class ExtraPayloadWidget(QTextEdit):
         self.setReadOnly(True)
         self.tx_type = 0
         self.extra_payload = b''
+        self.mn_alias = None
 
     def clear(self):
         super(ExtraPayloadWidget, self).clear()
         self.tx_type = 0
         self.extra_payload = b''
+        self.mn_alias = None
         self.setText('')
 
     def get_extra_data(self):
         return self.tx_type, self.extra_payload
 
-    def set_extra_data(self, tx_type, extra_payload):
+    def set_extra_data(self, tx_type, extra_payload, mn_alias=None):
         self.tx_type, self.extra_payload = tx_type, extra_payload
+        self.mn_alias = mn_alias
         tx_type_name = SPEC_TX_NAMES.get(tx_type, str(tx_type))
-        self.setText('Tx Type: %s\n\n%s' % (tx_type_name, extra_payload))
+        if self.mn_alias:
+            self.setText('Tx Type: %s, MN alias: %s\n\n%s' % (tx_type_name,
+                                                              mn_alias,
+                                                              extra_payload))
+        else:
+            self.setText('Tx Type: %s\n\n%s' % (tx_type_name, extra_payload))
 
 
 class VTabBar(QTabBar):

--- a/electrum_dash/gui/qt/protx_qt.py
+++ b/electrum_dash/gui/qt/protx_qt.py
@@ -759,15 +759,24 @@ class Dip3TabWidget(QTabWidget):
 
     @pyqtSlot()
     def on_make_pro_reg_tx(self):
+        alias = self.w_cur_alias
         try:
-            pro_reg_tx = self.manager.prepare_pro_reg_tx(self.w_cur_alias)
+            pro_reg_tx = self.manager.prepare_pro_reg_tx(alias)
         except ProRegTxExc as e:
             self.gui.show_error(e)
             return
-        self.gui.payto_e.setText(self.wallet.get_unused_address())
-        self.gui.extra_payload.set_extra_data(SPEC_PRO_REG_TX, pro_reg_tx)
-        self.gui.show_extra_payload()
-        self.gui.tabs.setCurrentIndex(self.gui.tabs.indexOf(self.gui.send_tab))
+        mn = self.manager.mns.get(alias)
+        gui = self.gui
+        gui.do_clear()
+        if mn.collateral.is_null:
+            gui.amount_e.setText('1000')
+        mn_addrs = [mn.owner_addr, mn.voting_addr, mn.payout_address]
+        for addr in self.wallet.get_unused_addresses():
+            if addr not in mn_addrs:
+                gui.payto_e.setText(addr)
+        gui.extra_payload.set_extra_data(SPEC_PRO_REG_TX, pro_reg_tx, alias)
+        gui.show_extra_payload()
+        gui.tabs.setCurrentIndex(self.gui.tabs.indexOf(self.gui.send_tab))
 
     @pyqtSlot()
     def on_file(self):

--- a/electrum_dash/gui/qt/protx_wizards.py
+++ b/electrum_dash/gui/qt/protx_wizards.py
@@ -1032,6 +1032,8 @@ class CollateralWizardPage(QWizardPage):
             excluded = wallet.frozen_addresses
         coins = wallet.get_utxos(domain=None, excluded_addresses=excluded,
                                  mature_only=True, confirmed_only=True)
+        if not self.frozen_cb.isChecked():
+            coins = [c for c in coins if not wallet.is_frozen_coin(c)]
         coins = list(filter(lambda x: (x['value'] == (1000 * COIN)), coins))
 
         if len(coins) > 0:

--- a/electrum_dash/gui/qt/protx_wizards.py
+++ b/electrum_dash/gui/qt/protx_wizards.py
@@ -1688,9 +1688,11 @@ class ExportToFileWizardPage(QWizardPage):
         layout.addWidget(self.lb_aliases)
         layout.addWidget(self.lw_aliases)
         self.setLayout(layout)
+        self.aliases = []
 
     def initializePage(self):
         self.parent.setButtonText(QWizard.CommitButton, 'Save')
+        self.aliases = [i.text() for i in self.lw_aliases.selectedItems()]
 
     @pyqtSlot()
     def on_selection_changed(self):

--- a/electrum_dash/gui/qt/protx_wizards.py
+++ b/electrum_dash/gui/qt/protx_wizards.py
@@ -13,8 +13,9 @@ from PyQt5.QtWidgets import (QLineEdit, QComboBox, QListWidget, QDoubleSpinBox,
                              QGroupBox, QCheckBox, QPushButton, QGridLayout,
                              QFileDialog, QWizard)
 
+from electrum_dash import constants
 from electrum_dash import dash_tx
-from electrum_dash.bitcoin import COIN, is_b58_address
+from electrum_dash.bitcoin import COIN, is_b58_address, b58_address_to_hash160
 from electrum_dash.dash_tx import TxOutPoint, service_to_ip_port
 from electrum_dash.protx import ProTxMN, ProTxService, ProRegTxExc
 from electrum_dash.util import bfh, bh2u
@@ -1583,8 +1584,6 @@ class Dip3MasternodeWizard(QWizard):
             raise ValidationError('Payout address must differ from owner'
                                   'and voting addresses')
 
-        if not self.wallet.is_mine(o_addr):
-            raise ValidationError('Owner address not found in the wallet')
         keystore = self.wallet.keystore
         if not hasattr(keystore, 'sign_digest') and not ignore_hw_warn:
             raise HwWarnError('Warning: sign_digest not implemented in '
@@ -1598,6 +1597,12 @@ class Dip3MasternodeWizard(QWizard):
             raise ValidationError('Wrong voting address format')
         if not is_b58_address(p_addr):
             raise ValidationError('Wrong payout address format')
+
+        if b58_address_to_hash160(o_addr)[0] != constants.net.ADDRTYPE_P2PKH:
+            raise ValidationError('Owner address must be of P2PKH type')
+        if b58_address_to_hash160(v_addr)[0] != constants.net.ADDRTYPE_P2PKH:
+            raise ValidationError('Voting address must be of P2PKH type')
+
         return o_addr, v_addr, p_addr
 
 

--- a/electrum_dash/gui/qt/protx_wizards.py
+++ b/electrum_dash/gui/qt/protx_wizards.py
@@ -905,8 +905,15 @@ class SaveDip3WizardPage(QWizardPage):
             except ProRegTxExc as e:
                 gui.show_error(e)
                 return True
-            gui.payto_e.setText(manager.wallet.get_unused_address())
-            gui.extra_payload.set_extra_data(tx_type, pro_tx)
+            gui.do_clear()
+            mn = self.new_mn
+            if mn.collateral.is_null:
+                gui.amount_e.setText('1000')
+            mn_addrs = [mn.owner_addr, mn.voting_addr, mn.payout_address]
+            for addr in manager.wallet.get_unused_addresses():
+                if addr not in mn_addrs:
+                    gui.payto_e.setText(addr)
+            gui.extra_payload.set_extra_data(tx_type, pro_tx, alias)
             gui.show_extra_payload()
             gui.tabs.setCurrentIndex(gui.tabs.indexOf(gui.send_tab))
             parent.pro_tx_prepared = tx_descr

--- a/electrum_dash/network.py
+++ b/electrum_dash/network.py
@@ -1064,9 +1064,15 @@ class Network(Logger):
             r"bad-qc-version",
             r"bad-qc-quorum-hash",
             r"bad-qc-type",
+            r"bad-qc-payload",
+            r"commitment-not-found",
+            r"excess-quorums",
+
 
             r"bad-protx-addr",
+            r"bad-protx-ipaddr",
             r"bad-protx-addr-port",
+            r"bad-protx-ipaddr-port",
             r"bad-protx-sig",
             r"bad-protx-inputs-hash",
             r"bad-protx-type",
@@ -1093,6 +1099,7 @@ class Network(Logger):
             r"bad-tx-type",
             r"bad-tx-type-check",
             r"bad-tx-type-proc",
+            r"failed-check-special-tx",
 
             r"bad-cbtx-type",
             r"bad-cbtx-invalid",
@@ -1100,6 +1107,8 @@ class Network(Logger):
             r"bad-cbtx-version",
             r"bad-cbtx-height",
             r"bad-cbtx-mnmerkleroot",
+            r"failed-calc-cb-mnmerkleroot",
+            r"failed-dmn-block",
 
             r"bad-txns-payload-oversize",
             r"bad-txns-type",

--- a/electrum_dash/protx.py
+++ b/electrum_dash/protx.py
@@ -23,6 +23,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import copy
 import threading
 from collections import defaultdict
 
@@ -100,7 +101,7 @@ class ProTxMN:
     def as_dict(self):
         res = {}
         for f in self.fields:
-            v = getattr(self, f)
+            v = copy.deepcopy(getattr(self, f))
             if isinstance(v, tuple):
                 res[f] = dict(v._asdict())
             else:
@@ -113,7 +114,7 @@ class ProTxMN:
         for f in cls.fields:
             if f not in d:
                 raise ProTxMNExc('Key %s is missing in supplied dict')
-            v = d[f]
+            v = copy.deepcopy(d[f])
             if f == 'collateral':
                 v['hash'] = bfh(v['hash'])[::-1]
                 setattr(mn, f, TxOutPoint(**v))
@@ -269,6 +270,8 @@ class ProTxManager(Logger):
         if not mn:
             raise ProRegTxExc('Masternode alias %s not found' % alias)
 
+        coll_hash_is_null = mn.collateral.hash_is_null
+
         if mn.protx_hash:
             raise ProRegTxExc('Masternode already registered')
 
@@ -279,7 +282,8 @@ class ProTxManager(Logger):
             raise ProRegTxExc('Collateral hash is not set')
 
         if not mn.collateral.index >= 0:
-            raise ProRegTxExc('Collateral index is not set')
+            if not coll_hash_is_null:
+                raise ProRegTxExc('Collateral index is not set')
 
         if mn.is_operated and not mn.service.ip:
             raise ProRegTxExc('Service IP address is not set')
@@ -307,17 +311,19 @@ class ProTxManager(Logger):
         KeyIdOwner = b58_address_to_hash160(mn.owner_addr)[1]
         PubKeyOperator = bfh(mn.pubkey_operator)
         KeyIdVoting = b58_address_to_hash160(mn.voting_addr)[1]
+        payloadSig = b'' if coll_hash_is_null else b'\x00'*65
 
         tx = DashProRegTx(1, mn.type, mn.mode, mn.collateral, mn.service.ip,
                           mn.service.port, KeyIdOwner, PubKeyOperator,
                           KeyIdVoting, mn.op_reward, scriptPayout,
-                          b'\x00'*32, b'\x00'*65)
+                          b'\x00'*32, payloadSig)
 
-        tx.payload_sig_msg_part = ('%s|%s|%s|%s|' %
-                                   (mn.payout_address,
-                                    mn.op_reward,
-                                    mn.owner_addr,
-                                    mn.voting_addr))
+        if not coll_hash_is_null:
+            tx.payload_sig_msg_part = ('%s|%s|%s|%s|' %
+                                       (mn.payout_address,
+                                        mn.op_reward,
+                                        mn.owner_addr,
+                                        mn.voting_addr))
         return tx
 
     def prepare_pro_up_srv_tx(self, mn):
@@ -373,6 +379,38 @@ class ProTxManager(Logger):
                             PubKeyOperator, KeyIdVoting, scriptPayout,
                             b'\x00'*32, b'\x00'*65)
         return tx
+
+    def find_mn_by_proregtx(self, tx):
+        txid = tx.txid()
+        ep = tx.extra_payload
+        ep_collateral = ep.collateralOutpoint
+        if ep_collateral.hash_is_null:
+            ep_service = ProTxService(ep.ipAddress, ep.port)
+            for alias, mn in self.mns.items():
+                if mn.protx_hash:
+                    continue
+                keyid_owner = b58_address_to_hash160(mn.owner_addr)[1]
+                pubkey_operator = bfh(mn.pubkey_operator)
+                keyid_voting = b58_address_to_hash160(mn.voting_addr)[1]
+                script_payout = bfh(Transaction.pay_script(TYPE_ADDRESS,
+                                                           mn.payout_address))
+                if (mn.type == ep.type and mn.mode == ep.mode
+                        and mn.collateral.hash_is_null
+                        and str(mn.service) == str(ep_service)
+                        and keyid_owner == ep.KeyIdOwner
+                        and pubkey_operator == ep.PubKeyOperator
+                        and keyid_voting == ep.KeyIdVoting
+                        and mn.op_reward == ep.operatorReward
+                        and script_payout == ep.scriptPayout):
+                    index = ep_collateral.index
+                    collateral = TxOutPoint(bfh(txid)[::-1], index)
+                    return mn, txid, collateral
+        else:
+            for alias, mn in self.mns.items():
+                if mn.protx_hash:
+                    continue
+                if str(mn.collateral) == str(ep_collateral):
+                    return mn, txid, None
 
     def prepare_pro_up_rev_tx(self, alias, reason):
         '''Prepare and return ProUpRevTx from ProTxMN alias'''

--- a/electrum_dash/tests/test_dash_tx.py
+++ b/electrum_dash/tests/test_dash_tx.py
@@ -1,6 +1,7 @@
 from electrum_dash import transaction
-from electrum_dash.dash_tx import DashTxError
-from electrum_dash.util import bfh
+from electrum_dash.dash_tx import DashTxError, TxOutPoint
+from electrum_dash.transaction import BCDataStream
+from electrum_dash.util import bfh, bh2u
 from electrum_dash.commands import Commands
 
 from . import SequentialTestCase
@@ -194,6 +195,49 @@ WRONG_SPEC_TX = (  # Tx version < 3
     '74150412caf3e98e9601210293360bf2a2e810673412bc6e8e0e358f3fb7bdbe9a667b'
     '3d0103f761cc69a211feffffff0189fa433e000000001976a914551ab8ca96a9142217'
     '4d22769c3a4f90b2dcd0de88ac00000000')
+
+
+TEST_HASH = 'a7b64e6eab08bf2b87e64f6a248eb7eeef8a3c7fe07cadb0c631090100bb0002'
+
+
+class TestDashTx(SequentialTestCase):
+
+    def test_tx_outpoint(self):
+        # test normal outpoint
+        o = TxOutPoint(bfh(TEST_HASH)[::-1], 1)
+        assert o.is_null == False
+        assert o.hash_is_null == False
+        assert str(o) == TEST_HASH + ':1'
+        ser = o.serialize()
+        assert bh2u(ser) == bh2u(bfh(TEST_HASH)[::-1]) + '01000000'
+        s = BCDataStream()
+        s.write(ser)
+        o2 = TxOutPoint.read_vds(s)
+        assert str(o2) == str(o)
+
+        # test null outpoint
+        o = TxOutPoint(b'\x00'*32, -1)
+        assert o.is_null == True
+        assert o.hash_is_null == True
+        assert str(o) == '0'*64 + ':-1'
+        ser = o.serialize()
+        assert bh2u(ser) == '0'*64 + 'f'*8
+        s = BCDataStream()
+        s.write(ser)
+        o2 = TxOutPoint.read_vds(s)
+        assert str(o2) == str(o)
+
+        # test null hash
+        o = TxOutPoint(b'\x00'*32, 0)
+        assert o.is_null == False
+        assert o.hash_is_null == True
+        assert str(o) == '0'*64 + ':0'
+        ser = o.serialize()
+        assert bh2u(ser) == '0'*64 + '00000000'
+        s = BCDataStream()
+        s.write(ser)
+        o2 = TxOutPoint.read_vds(s)
+        assert str(o2) == str(o)
 
 
 class TestDashSpecTxSerialization(SequentialTestCase):

--- a/electrum_dash/tests/test_protx.py
+++ b/electrum_dash/tests/test_protx.py
@@ -1,0 +1,56 @@
+import unittest
+
+from electrum_dash.dash_tx import TxOutPoint
+from electrum_dash.protx import ProTxMN
+
+
+class ProTxTestCase(unittest.TestCase):
+
+    def test_protxmn(self):
+        mn_dict = {
+            'alias': 'default',
+            'bls_privk': '702ac35f02311c6b3209538c2784c21a'
+                         '066d767b53d5a7c69fd677f1949a76a5',
+            'collateral': {
+                'hash': '0'*64,
+                'index': -1
+            },
+            'is_operated': True,
+            'is_owned': True,
+            'mode': 0,
+            'op_payout_address': '',
+            'op_reward': 0,
+            'owner_addr': 'yevc1CQmqyPWJjz1kg9KbnAvov8K3RmaYz',
+            'payout_address': 'ygeCXmn4ysXxL1DmUAcmuG5WA6QwNJbr3b',
+            'protx_hash': '',
+            'pubkey_operator': '012152114d9b7edaa5473c93858f8c11'
+                               'fa12b6f8afa37a40ed335407b207f7c8'
+                               'caa46092586c369daba06cfda00893ae',
+            'service': {
+                'ip': '127.0.0.1',
+                'port': 9999
+            },
+            'type': 0,
+            'voting_addr': 'yevc1CQmqyPWJjz1kg9KbnAvov8K3RmaYz'}
+
+        mn = ProTxMN.from_dict(mn_dict)
+        assert mn.alias == 'default'
+        assert mn.is_owned == True
+        assert mn.is_operated == True
+        assert mn.bls_privk == ('702ac35f02311c6b3209538c2784c21a'
+                                '066d767b53d5a7c69fd677f1949a76a5')
+        assert mn.type == 0
+        assert mn.mode == 0
+        assert mn.collateral == TxOutPoint(b'\x00'*32, -1)
+        assert str(mn.service) == '127.0.0.1:9999'
+        assert mn.owner_addr == 'yevc1CQmqyPWJjz1kg9KbnAvov8K3RmaYz'
+        assert mn.pubkey_operator == ('012152114d9b7edaa5473c93858f8c11'
+                                      'fa12b6f8afa37a40ed335407b207f7c8'
+                                      'caa46092586c369daba06cfda00893ae')
+        assert mn.voting_addr == 'yevc1CQmqyPWJjz1kg9KbnAvov8K3RmaYz'
+        assert mn.op_reward == 0
+        assert mn.payout_address == 'ygeCXmn4ysXxL1DmUAcmuG5WA6QwNJbr3b'
+        assert mn.op_payout_address == ''
+        assert mn.protx_hash == ''
+        mn_dict2 = mn.as_dict()
+        assert mn_dict2 == mn_dict


### PR DESCRIPTION
- qt:protx_wizard: exclude frozen coins/addrs
- qt:protx_wizard: support creating collateral with ProRegTx
- qt:protx_wizard: fix ExportToFileWizardPage
- qt:protx_wizard: limit Owner/Voting addresses to P2PKH
- dash_tx: add null outpoint to TxOutPoint, tests
- network: add new dash error messages
- protx/dash_tx/qt ui: support sending ProRegTx with null outpoint
- commands.py: remove legacy masternodes commands
