### PR TITLE
qt protx: fix payto address selection

### DIFF
--- a/electrum_dash/gui/qt/protx_qt.py
+++ b/electrum_dash/gui/qt/protx_qt.py
@@ -774,6 +774,7 @@ class Dip3TabWidget(QTabWidget):
         for addr in self.wallet.get_unused_addresses():
             if addr not in mn_addrs:
                 gui.payto_e.setText(addr)
+                break
         gui.extra_payload.set_extra_data(SPEC_PRO_REG_TX, pro_reg_tx, alias)
         gui.show_extra_payload()
         gui.tabs.setCurrentIndex(self.gui.tabs.indexOf(self.gui.send_tab))

--- a/electrum_dash/gui/qt/protx_wizards.py
+++ b/electrum_dash/gui/qt/protx_wizards.py
@@ -913,6 +913,7 @@ class SaveDip3WizardPage(QWizardPage):
             for addr in manager.wallet.get_unused_addresses():
                 if addr not in mn_addrs:
                     gui.payto_e.setText(addr)
+                    break
             gui.extra_payload.set_extra_data(tx_type, pro_tx, alias)
             gui.show_extra_payload()
             gui.tabs.setCurrentIndex(gui.tabs.indexOf(gui.send_tab))


### PR DESCRIPTION
Fix https://github.com/akhavr/electrum-dash/pull/119 changes, add lost breaks in payto address selection.