### PR TITLE
PrivateSend: add support to mix on hw wallets (using ps_keystore)

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,5 +1,6 @@
-# Release 3.3.8.7 (not released yet)
+# Release 3.3.8.7
 
+ * PrivateSend: support mixing on hardware wallets (using ps_keystore)
  * qt: fix exported files file mode
 
 

--- a/electrum_dash/commands.py
+++ b/electrum_dash/commands.py
@@ -814,7 +814,6 @@ param_descriptions = {
 }
 
 command_options = {
-    'broadcast':   (None, "Broadcast the transaction to the Dash network"),
     'password':    ("-W", "Password"),
     'new_password':(None, "New Password"),
     'encrypt_file':(None, "Whether the file on disk should be encrypted with the provided password"),
@@ -859,10 +858,8 @@ command_options = {
 from .transaction import tx_from_str
 json_loads = lambda x: json.loads(x, parse_float=lambda x: str(Decimal(x)))
 arg_types = {
-    'block_start': int,
     'num': int,
     'nbits': int,
-    'payments_count': int,
     'imax': int,
     'year': int,
     'from_height': int,

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -20,11 +20,11 @@ from .dash_tx import (STANDARD_TX, PSTxTypes, SPEC_TX_NAMES, PSCoinRounds,
 from .dash_msg import (DSPoolStatusUpdate, DSMessageIDs, ds_msg_str,
                        ds_pool_state_str, DashDsaMsg, DashDsiMsg, DashDssMsg,
                        PRIVATESEND_ENTRY_MAX_SIZE)
-from .keystore import xpubkey_to_address, load_keystore
+from .keystore import xpubkey_to_address, load_keystore, from_seed
 from .logging import Logger
 from .transaction import Transaction, TxOutput
 from .util import (NoDynamicFeeEstimates, log_exceptions, SilentTaskGroup,
-                   NotEnoughFunds, bfh, is_android, profiler)
+                   NotEnoughFunds, bfh, is_android, profiler, InvalidPassword)
 from .i18n import _
 
 
@@ -825,7 +825,7 @@ class PSManager(Logger):
         self.config = None
         self._state = PSStates.Unsupported
         self.wallet_types_supported = ['standard']
-        self.keystore_types_supported = ['bip32']
+        self.keystore_types_supported = ['bip32', 'hardware']
         keystore = wallet.db.get('keystore')
         self._allow_others = DEFAULT_ALLOW_OTHERS
         if keystore:
@@ -851,6 +851,9 @@ class PSManager(Logger):
                                      f' and kestore type "{this_ks_type}".')
         else:
             self.unsupported_msg = ''
+
+        if self.is_hw_ks:
+            self.enable_ps_keystore()
 
         self.network = None
         self.dash_net = None
@@ -905,7 +908,15 @@ class PSManager(Logger):
     def enabled(self):
         return self.state not in [PSStates.Unsupported, PSStates.Disabled]
 
+    @property
+    def is_hw_ks(self):
+        return self.w_ks_type == 'hardware'
+
     def enable_ps(self):
+        if (self.w_type == 'standard' and self.is_hw_ks
+                and 'ps_keystore' not in self.wallet.db.data):
+            self.logger.info(f'ps_keystore for hw wallets must be created')
+            return
         if not self.enabled:
             self.wallet.db.set_ps_data('ps_enabled', True)
             coro = self._enable_ps()
@@ -956,18 +967,68 @@ class PSManager(Logger):
             self.ps_keystore = load_keystore(w.storage, 'ps_keystore')
 
     def enable_ps_keystore(self):
-        w = self.wallet
         if self.w_type == 'standard':
             if self.w_ks_type == 'bip32':
                 self.copy_standard_bip32_keystore()
                 self.load_ps_keystore()
+            elif self.is_hw_ks:
+                self.load_ps_keystore()
+        if self.ps_keystore:
+            self.synchronize()
 
     def after_wallet_password_set(self, old_pw, new_pw):
         if not self.ps_keystore:
             return
         if self.w_type == 'standard':
             if self.w_ks_type == 'bip32':
-                self.enable_ps_keystore()
+                self.copy_standard_bip32_keystore()
+                self.load_ps_keystore()
+
+    def create_ps_ks_from_seed_ext_password(self, seed, seed_ext, password):
+        if not self.is_hw_ks:
+            raise Exception(f'can not create ps_keystore when main keystore'
+                            f' type: "{self.w_ks_type}"')
+        w = self.wallet
+        if w.storage.get('ps_keystore', {}):
+            raise Exception('ps_keystore already exists')
+        keystore = from_seed(seed, seed_ext, False)
+        keystore.update_password(None, password)
+        ps_keystore = keystore.dump()
+        ps_keystore.update({'type': 'ps_bip32'})
+        w.storage.put('ps_keystore', ps_keystore)
+        self.enable_ps_keystore()
+
+    def is_ps_ks_encrypted(self):
+        if self.ps_keystore:
+            try:
+                self.ps_keystore.check_password(None)
+                return False
+            except:
+                return True
+
+    def need_password(self):
+        return (self.wallet.has_keystore_encryption()
+                or self.is_hw_ks and self.is_ps_ks_encrypted())
+
+    def update_ps_ks_password(self, old_pw, new_pw):
+        if not self.is_hw_ks:
+            raise Exception(f'can not create ps_keystore for main keystore'
+                            f' type: "{self.w_ks_type}"')
+        if old_pw is None and self.is_ps_ks_encrypted():
+            raise InvalidPassword()
+        self.ps_keystore.check_password(old_pw)
+
+        if old_pw is None and new_pw:
+            self.on_wallet_password_set()
+
+        self.ps_keystore.update_password(old_pw, new_pw)
+        self.wallet.storage.put('ps_keystore', self.ps_keystore.dump())
+        self.wallet.storage.write()
+
+    def is_ps_ks_inputs_in_tx(self, tx):
+        for txin in tx.inputs():
+            if self.is_ps_ks(txin['address']):
+                return True
 
     # methods related to ps_keystore
     def pubkeys_to_address(self, pubkey):
@@ -1087,9 +1148,12 @@ class PSManager(Logger):
         else:
             domain = self.get_receiving_addresses()
         ps_reserved = self.wallet.db.get_ps_reserved()
+        tmp_reserved_addr = self.get_tmp_reserved_address()
+        tmp_reserved_addrs = [tmp_reserved_addr] if tmp_reserved_addr else []
         return [addr for addr in domain if not self.wallet.is_used(addr)
                 and addr not in self.wallet.receive_requests.keys()
-                and addr not in ps_reserved]
+                and addr not in ps_reserved
+                and addr not in tmp_reserved_addrs]
 
     def add_input_info(self, txin):
         w = self.wallet
@@ -1117,9 +1181,8 @@ class PSManager(Logger):
             return
         w = self.wallet
         # enable ps_keystore and syncronize addresses
-        self.enable_ps_keystore()
-        if self.ps_keystore:
-            self.synchronize()
+        if not self.ps_keystore:
+            self.enable_ps_keystore()
         # check last_mix_stop_time if it was not saved on wallet crash
         last_mix_start_time = self.last_mix_start_time
         last_mix_stop_time = self.last_mix_stop_time
@@ -1614,6 +1677,13 @@ class PSManager(Logger):
         self.wallet.db.update_ps_data('denominate_workflows', wfl_dict)
         self.postpone_notification('ps-wfl-changes', self.wallet)
 
+    def set_tmp_reserved_address(self, address):
+        '''Used to reserve address to not be used in ps reservation'''
+        self.wallet.db.set_ps_data('tmp_reserved_address', address)
+
+    def get_tmp_reserved_address(self):
+        return self.wallet.db.get_ps_data('tmp_reserved_address', '')
+
     def mixing_control_data(self, full_txt=False):
         if full_txt:
             return _('Control PrivateSend mixing process')
@@ -1721,6 +1791,17 @@ class PSManager(Logger):
             return _('Show privacy warning about ElectrumX servers usage')
         else:
             return _('Privacy Warning ...')
+
+    @property
+    def show_warn_ps_ks(self):
+        return self.wallet.db.get_ps_data('show_warn_ps_ks', True)
+
+    @show_warn_ps_ks.setter
+    def show_warn_ps_ks(self, show):
+        self.wallet.db.set_ps_data('show_warn_ps_ks', show)
+
+    def warn_ps_ks_data(self):
+        return _('Show warning on exit if PS Keystore contain funds')
 
     def get_ps_data_info(self):
         res = []
@@ -1899,7 +1980,7 @@ class PSManager(Logger):
 
     def check_need_new_keypairs(self):
         w = self.wallet
-        if not w.has_password():
+        if not self.need_password():
             return False, None
 
         with self.keypairs_state_lock:
@@ -1980,6 +2061,13 @@ class PSManager(Logger):
         if kp_left is None:
             return
 
+        if self._cache_kp_tmp_reserved(password):
+            kp_left, kp_chg_left = self._cache_kp_ps_coins(password,
+                                                           kp_left + 1,
+                                                           kp_chg_left)
+            if kp_left is None:
+                return
+
         with self.keypairs_state_lock:
             self.keypairs_state = KPStates.Ready
         self.logger.info('Keyparis Cache Done')
@@ -1992,6 +2080,8 @@ class PSManager(Logger):
                             excluded_addresses=w.frozen_addresses,
                             mature_only=True)
         utxos = [utxo for utxo in utxos if not w.is_frozen_coin(utxo)]
+        if self.is_hw_ks:
+            utxos = [utxo for utxo in utxos if utxo['is_ps_ks']]
         for c in utxos:
             if self.state != PSStates.Mixing:
                 self._cleanup_unfinished_keypairs_cache()
@@ -2032,6 +2122,8 @@ class PSManager(Logger):
             if ps_denom and ps_denom[2] >= self.mix_rounds:
                 continue
             addr = c['address']
+            if self.is_hw_ks and not self.is_ps_ks(addr):
+                continue  # skip denoms on hw keystore
             if addr in ps_spendable_cache:
                 continue
             sequence = None
@@ -2062,6 +2154,8 @@ class PSManager(Logger):
                 return None, None
             if w.is_used(addr):
                 continue
+            if self.is_hw_ks and not self.is_ps_ks(addr):
+                continue  # skip denoms on hw keystore
             if w.is_change(addr):
                 sign_change_cnt -= 1
                 if addr in ps_change_cache:
@@ -2174,6 +2268,32 @@ class PSManager(Logger):
                                  f' of {KP_PS_COINS} type')
                 self.postpone_notification('ps-keypairs-changes', self.wallet)
         return sign_cnt, sign_change_cnt
+
+    def _cache_kp_tmp_reserved(self, password):
+        w = self.wallet
+        addr = self.get_tmp_reserved_address()
+        if not addr:
+            return False
+        if self.ps_keystore:
+            sequence = self.get_address_index(addr)
+        if sequence:
+            x_pubkey = self.ps_keystore.get_xpubkey(*sequence)
+            sec = self.ps_keystore.get_private_key(sequence, password)
+        else:
+            sequence = w.get_address_index(addr)
+            x_pubkey = w.keystore.get_xpubkey(*sequence)
+            sec = w.keystore.get_private_key(sequence, password)
+        spendable_cache = self._keypairs_cache[KP_SPENDABLE]
+        spendable_cache[addr] = (x_pubkey, sec)
+        self.logger.info(f'Cached key of {KP_SPENDABLE} type'
+                         f' for tmp reserved address')
+        self.postpone_notification('ps-keypairs-changes', self.wallet)
+        ps_coins_cache = self._keypairs_cache[KP_PS_COINS]
+        if addr in ps_coins_cache:
+            ps_coins_cache.pop(addr, None)
+            return True
+        else:
+            return False
 
     def _find_addrs_not_in_keypairs(self, addrs):
         addrs = set(addrs)
@@ -2404,6 +2524,9 @@ class PSManager(Logger):
         async def main():
             try:
                 async with main_taskgroup as group:
+                    if (self.w_type == 'standard'
+                            and self.is_hw_ks):
+                        await group.spawn(self._prepare_funds_from_hw_wallet())
                     await group.spawn(self._make_keypairs_cache(password))
                     await group.spawn(self._check_all_mixed())
                     await group.spawn(self._maintain_pay_collateral_tx())
@@ -2411,7 +2534,7 @@ class PSManager(Logger):
                     await group.spawn(self._maintain_denoms())
                     await group.spawn(self._mix_denoms())
             except Exception as e:
-                self.logger.exception('')
+                self.logger.info(f'error starting mixing: {str(e)}')
                 raise e
         asyncio.run_coroutine_threadsafe(main(), self.loop)
         with self.state_lock:
@@ -2495,7 +2618,7 @@ class PSManager(Logger):
                                                          'inf')
 
     async def _maintain_pay_collateral_tx(self):
-        kp_wait_state = KPStates.Ready if self.wallet.has_password() else None
+        kp_wait_state = KPStates.Ready if self.need_password() else None
 
         while not self.main_taskgroup.closed():
             wfl = self.pay_collateral_wfl
@@ -2530,7 +2653,7 @@ class PSManager(Logger):
                 await asyncio.sleep(1)
 
     async def _maintain_collateral_amount(self):
-        kp_wait_state = KPStates.Ready if self.wallet.has_password() else None
+        kp_wait_state = KPStates.Ready if self.need_password() else None
 
         while not self.main_taskgroup.closed():
             wfl = self.new_collateral_wfl
@@ -2554,7 +2677,7 @@ class PSManager(Logger):
             await asyncio.sleep(0.25)
 
     async def _maintain_denoms(self):
-        kp_wait_state = KPStates.Ready if self.wallet.has_password() else None
+        kp_wait_state = KPStates.Ready if self.need_password() else None
 
         while not self.main_taskgroup.closed():
             wfl = self.new_denoms_wfl
@@ -2577,7 +2700,7 @@ class PSManager(Logger):
             await asyncio.sleep(0.25)
 
     async def _mix_denoms(self):
-        kp_wait_state = KPStates.Ready if self.wallet.has_password() else None
+        kp_wait_state = KPStates.Ready if self.need_password() else None
 
         def _cleanup():
             for uuid in self.denominate_wfl_list:
@@ -2638,10 +2761,21 @@ class PSManager(Logger):
             sess.close_peer()
             return sess
 
-    def reserve_addresses(self, addrs_count, for_change=False, data=None):
+    def reserve_addresses(self, addrs_count, for_change=False,
+                          data=None, force_main_ks=False, tmp=False):
+        '''Reserve addresses for PS use or if tmp is True reserve one
+           receiving address temporarily to not be reserved for ps
+           during funds are sent to it'''
+        if tmp and addrs_count > 1:
+            raise Exception('tmp can be used only for one address reservation')
+        if tmp and for_change:
+            raise Exception('tmp param can not be used with for_change param')
+        if tmp and data is not None:
+            raise Exception('tmp param can not be used with data param')
+
         result = []
         w = self.wallet
-        ps_ks = self.ps_keystore is not None
+        ps_ks = self.ps_keystore and not force_main_ks
         with w.lock:
             while len(result) < addrs_count:
                 if for_change:
@@ -2655,7 +2789,10 @@ class PSManager(Logger):
                 else:
                     addr = (self.create_new_address(for_change) if ps_ks
                             else w.create_new_address(for_change))
-                self.add_ps_reserved(addr, data)
+                if tmp:
+                    self.set_tmp_reserved_address(addr)
+                else:
+                    self.add_ps_reserved(addr, data)
                 result.append(addr)
         return result
 
@@ -2748,9 +2885,10 @@ class PSManager(Logger):
         if coins_val < MIN_DENOM_VAL:  # no coins to create denoms
             return []
 
+        in_cnt = len(coins)
         approx_val = need_val - old_denoms_val
         outputs_amounts = self.find_denoms_approx(approx_val)
-        if coins_val >= self._calc_total_need_val(coins, outputs_amounts,
+        if coins_val >= self._calc_total_need_val(in_cnt, outputs_amounts,
                                                   fee_per_kb):
             return outputs_amounts
 
@@ -2759,13 +2897,13 @@ class PSManager(Logger):
             if approx_val < CREATE_COLLATERAL_VAL:
                 return []
             outputs_amounts = self.find_denoms_approx(approx_val)
-            if coins_val >= self._calc_total_need_val(coins, outputs_amounts,
+            if coins_val >= self._calc_total_need_val(in_cnt, outputs_amounts,
                                                       fee_per_kb):
                 return outputs_amounts
             else:
                 approx_val -= MIN_DENOM_VAL
 
-    def _calc_total_need_val(self, coins, outputs_amounts, fee_per_kb):
+    def _calc_total_need_val(self, txin_cnt, outputs_amounts, fee_per_kb):
         new_denoms_val = sum([sum(a) for a in outputs_amounts])
         new_denoms_cnt = sum([len(a) for a in outputs_amounts])
 
@@ -2780,7 +2918,7 @@ class PSManager(Logger):
         new_denoms_fee = 0
         for i, amounts in enumerate(outputs_amounts):
             if i == 0:  # use all coins as inputs, add change output
-                new_denoms_fee += calc_tx_fee(len(coins), len(amounts) + 1,
+                new_denoms_fee += calc_tx_fee(txin_cnt, len(amounts) + 1,
                                               fee_per_kb, max_size=True)
             else:  # use change from prev txs as input
                 new_denoms_fee += calc_tx_fee(1, len(amounts) + 1,
@@ -2923,6 +3061,83 @@ class PSManager(Logger):
         # no change, one coin input, one 10000 output
         new_collateral_fee = calc_tx_fee(1, 1, fee_per_kb, max_size=True)
         return new_collateral_fee + COLLATERAL_VAL
+
+    # Methods related to mixing on hw wallets
+    def prepare_funds_from_hw_wallet(self):
+        try:
+            w = self.wallet
+            fee_per_kb = self.config.fee_per_kb()
+            # calc amount need to be sent to ps_keystore
+            coins = w.get_utxos(None, excluded_addresses=w.frozen_addresses,
+                                mature_only=True)
+            coins = [c for c in coins if not w.is_frozen_coin(c)]
+            coins_val = sum([c['value'] for c in coins])
+            main_ks_coins = [c for c in coins if not c['is_ps_ks']]
+            main_ks_coins_val = sum([c['value'] for c in main_ks_coins])
+            ps_ks_coins_val = sum([c['value'] for c in coins if c['is_ps_ks']])
+
+            outputs_amounts = self.calc_need_denoms_amounts()
+            total_need_val = self._calc_total_need_val(len(coins),
+                                                       outputs_amounts,
+                                                       fee_per_kb)
+            transfer_tx_fee = calc_tx_fee(len(main_ks_coins), 1,
+                                          fee_per_kb, max_size=True)
+            if coins_val < total_need_val + transfer_tx_fee:  # transfer all
+                need_transfer_val = main_ks_coins_val - transfer_tx_fee
+            else:
+                need_transfer_val = total_need_val - ps_ks_coins_val
+            if need_transfer_val < PS_DENOMS_VALS[0]:
+                return
+            # prepare and send transaction to ps_keystore unused address
+            unused = self.reserve_addresses(1, tmp=True)
+            ps_ks_oaddr = unused[0]
+            outputs = [TxOutput(TYPE_ADDRESS, ps_ks_oaddr, need_transfer_val)]
+            tx = w.make_unsigned_transaction(main_ks_coins, outputs,
+                                             self.config)
+            tx = self.wallet.sign_transaction(tx, None)
+            if tx and tx.is_complete():
+                return tx
+        except BaseException as e:
+            self.logger.wfl_err(f'prepare_funds_from_hw_wallet: {str(e)}')
+
+    async def _prepare_funds_from_hw_wallet(self):
+        while True:
+            tx = self.prepare_funds_from_hw_wallet()
+            if tx:
+                await self.broadcast_transaction(tx)
+                self.logger.info(f'Broadcasted PS Keystore'
+                                 f' fund tx {tx.txid()}')
+            await asyncio.sleep(30)
+
+    def prepare_funds_from_ps_keystorere(self, password):
+        w = self.wallet
+        coins = w.get_utxos(None, excluded_addresses=w.frozen_addresses,
+                            mature_only=True, include_ps=True)
+        coins = [c for c in coins if not w.is_frozen_coin(c)]
+        ps_ks_coins = [c for c in coins if c['is_ps_ks']]
+        if not ps_ks_coins:
+            raise NotEnoughFunds('No funds found on PS Keystore')
+        unused = w.get_unused_addresses()
+        if not unused:
+            raise NotEnoughFunds('No unused addresses to prepare transaction')
+        outputs = [TxOutput(TYPE_ADDRESS, unused[0], '!')]
+        tx = w.make_unsigned_transaction(ps_ks_coins, outputs, self.config)
+        tx = self.wallet.sign_transaction(tx, password)
+        if tx and tx.is_complete():
+            return tx
+        else:
+            raise Exception('Sign transaction failed')
+
+    def check_funds_on_ps_keystorere(self):
+        w = self.wallet
+        coins = w.get_utxos(None, excluded_addresses=w.frozen_addresses,
+                            mature_only=True, include_ps=True)
+        coins = [c for c in coins if not w.is_frozen_coin(c)]
+        ps_ks_coins = [c for c in coins if c['is_ps_ks']]
+        if ps_ks_coins:
+            return True
+        else:
+            return False
 
     # Workflow methods for pay collateral transaction
     def get_confirmed_ps_collateral_data(self):
@@ -3283,6 +3498,8 @@ class PSManager(Logger):
                                 mature_only=True, confirmed_only=True,
                                 consider_islocks=True)
             utxos = [utxo for utxo in utxos if not w.is_frozen_coin(utxo)]
+            if self.w_ks_type != 'bip32':  # filter coins from ps_keystore
+                utxos = [utxo for utxo in utxos if utxo['is_ps_ks']]
             utxos_val = sum([utxo['value'] for utxo in utxos])
             # try calc fee with change output
             new_collateral_fee = calc_tx_fee(len(utxos), 2, fee_per_kb,
@@ -3684,6 +3901,8 @@ class PSManager(Logger):
                                 confirmed_only=use_confirmed,
                                 consider_islocks=True)
             utxos = [utxo for utxo in utxos if not w.is_frozen_coin(utxo)]
+            if self.w_ks_type != 'bip32':  # filter coins from ps_keystore
+                utxos = [utxo for utxo in utxos if utxo['is_ps_ks']]
         else:
             utxos = coins
         tx = w.make_unsigned_transaction(utxos, outputs, self.config)
@@ -3995,7 +4214,7 @@ class PSManager(Logger):
         if not self._denoms_to_mix_cache:
             self.logger.debug(f'No suitable denoms to mix,'
                               f' _denoms_to_mix_cache is empty')
-            return None, None, None
+            return None, None
 
         if denom_value is not None:
             denoms = self.denoms_to_mix(denom_value=denom_value)
@@ -4067,6 +4286,8 @@ class PSManager(Logger):
                     continue  # already spent
                 if w.db.get_ps_spending_denom(outpoint):
                     continue  # already used by other wfl
+                if self.is_hw_ks and not self.is_ps_ks(denom[0]):
+                    continue  # skip denoms from hardware keystore
                 inputs.append(outpoint)
                 input_addrs.append(denom[0])
                 icnt += 1
@@ -4101,7 +4322,13 @@ class PSManager(Logger):
                 found_outpoints.append(data)
         for outpoint in inputs:
             if outpoint not in found_outpoints:
-                reserved = self.reserve_addresses(1, data=outpoint)
+                force_main_ks = False
+                if self.is_hw_ks:
+                    denom = w.db.get_ps_denom(outpoint)
+                    if denom[2] == self.mix_rounds - 1:
+                        force_main_ks = True
+                reserved = self.reserve_addresses(1, data=outpoint,
+                                                  force_main_ks=force_main_ks)
                 output_addrs.append(reserved[0])
 
         with self.denominate_wfl_lock:
@@ -4858,6 +5085,32 @@ class PSManager(Logger):
             idx += 1
         return False
 
+    def _calc_rounds_for_denominate_tx(self, new_outpoints, input_rounds):
+        output_rounds = list(map(lambda x: x+1, input_rounds[:]))
+        if self.is_hw_ks:
+            max_round = max(output_rounds)
+            min_round = min(output_rounds)
+            if min_round < max_round:
+                hw_addrs_idxs = []
+                for i, (new_outpoint, addr, value) in enumerate(new_outpoints):
+                    if not self.is_ps_ks(addr):
+                        hw_addrs_idxs.append(i)
+                if hw_addrs_idxs:
+                    max_round_idxs = []
+                    for i, r in enumerate(output_rounds):
+                        if r == max_round:
+                            max_round_idxs.append(i)
+                    res_rounds = [r for r in output_rounds if r < max_round]
+                    while max_round_idxs:
+                        r = output_rounds[max_round_idxs.pop(0)]
+                        if hw_addrs_idxs:
+                            i = hw_addrs_idxs.pop(0)
+                            res_rounds.insert(i, r)
+                        else:
+                            res_rounds.append(r)
+                    output_rounds = res_rounds[:]
+        return output_rounds
+
     def _add_denominate_ps_data(self, txid, tx):
         w = self.wallet
         spent_outpoints = []
@@ -4900,9 +5153,10 @@ class PSManager(Logger):
                 input_rounds.append(spent_denom[2])
             self.add_spent_addrs(spent_ps_addrs)
 
-            random.shuffle(input_rounds)
+            output_rounds = self._calc_rounds_for_denominate_tx(new_outpoints,
+                                                                input_rounds)
             for i, (new_outpoint, addr, value) in enumerate(new_outpoints):
-                new_denom = (addr, value, input_rounds[i]+1)
+                new_denom = (addr, value, output_rounds[i])
                 self.add_ps_denom(new_outpoint, new_denom)
                 self.pop_ps_reserved(addr)
 

--- a/electrum_dash/gui/qt/address_list.py
+++ b/electrum_dash/gui/qt/address_list.py
@@ -464,7 +464,7 @@ class AddressList(MyTreeView):
             if not is_ps and not is_ps_ks:
                 menu.addAction(_("Request payment"),
                                lambda: self.parent.receive_at(addr))
-            if self.wallet.can_export():
+            if self.wallet.can_export() or self.wallet.psman.is_ps_ks(addr):
                 menu.addAction(_("Private key"),
                                lambda: self.parent.show_private_key(addr))
             if not is_multisig and not self.wallet.is_watching_only():

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -94,7 +94,8 @@ from .update_checker import UpdateCheck, UpdateCheckThread
 from .masternode_dialog import MasternodeDialog
 from .dash_qt import ExtraPayloadWidget
 from .privatesend_dialog import (find_ps_dialog, show_ps_dialog,
-                                 hide_ps_dialog, protected_with_parent)
+                                 hide_ps_dialog, protected_with_parent,
+                                 show_ps_dialog_or_wizard)
 from .protx_qt import create_dip3_tab
 
 
@@ -710,7 +711,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.private_keys_menu = wallet_menu.addMenu(_("&Private keys"))
         self.private_keys_menu.addAction(_("&Sweep"), self.sweep_key_dialog)
         self.import_privkey_menu = self.private_keys_menu.addAction(_("&Import"), self.do_import_privkey)
-        self.export_menu = self.private_keys_menu.addAction(_("&Export"), self.export_privkeys_dialog)
+
+        def export_privk_dlg():
+            self.export_privkeys_dialog(mwin=self, parent=self)
+        self.export_menu = self.private_keys_menu.addAction(_("&Export"),
+                                                            export_privk_dlg)
         self.import_address_menu = wallet_menu.addAction(_("Import addresses"), self.import_addresses)
         wallet_menu.addSeparator()
 
@@ -750,7 +755,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         add_toggle_action(view_menu, self.console_tab)
 
         wallet_menu.addSeparator()
-        wallet_menu.addAction(_('PrivateSend'), lambda: show_ps_dialog(self))
+
+        wallet_menu.addAction(_('PrivateSend'),
+                              lambda: show_ps_dialog_or_wizard(self))
 
         tools_menu = menubar.addMenu(_("&Tools"))
 
@@ -1804,6 +1811,49 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             return func(self, *args, **kwargs)
         return request_password
 
+    def ps_ks_protected(func):
+        def request_ps_ks_password(self, *args, **kwargs):
+            psman = self.wallet.psman
+            if not psman.is_hw_ks:
+                return func(self, *args, **kwargs)
+            if not psman.is_ps_ks_encrypted():
+                return func(self, *args, **kwargs)
+            fname = func.__name__
+            if fname == 'do_sign':
+                addr_edit = args[0]
+                addr = addr_edit.text().strip()
+                if not psman.is_ps_ks(addr):
+                    return func(self, *args, **kwargs)
+            elif fname == 'do_decrypt':
+                pubkey_edit = args[1]
+                pubkey = pubkey_edit.text().strip()
+                addr = psman.pubkeys_to_address(pubkey)
+                if not psman.is_ps_ks(addr):
+                    return func(self, *args, **kwargs)
+            elif fname == 'sign_tx':
+                tx = args[0]
+                if not psman.is_ps_ks_inputs_in_tx(tx):
+                    return func(self, *args, **kwargs)
+            elif fname not in ['_delete_wallet', 'show_private_key']:
+                return func(self, *args, **kwargs)
+
+            parent = self.top_level_window()
+            password = None
+            while psman.is_ps_ks_encrypted():
+                password = self.password_dialog(parent=parent)
+                if password is None:
+                    # User cancelled password input
+                    return
+                try:
+                    psman.ps_keystore.check_password(password)
+                    break
+                except Exception as e:
+                    self.show_error(str(e), parent=parent)
+                    continue
+            kwargs['password'] = password
+            return func(self, *args, **kwargs)
+        return request_ps_ks_password
+
     def is_send_fee_frozen(self):
         return self.fee_e.isVisible() and self.fee_e.isModified() \
                and (self.fee_e.text() or self.fee_e.hasFocus())
@@ -1946,7 +1996,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         if fee > feerate_warning * tx.estimated_size() / 1000:
             msg.append(_('Warning') + ': ' + _("The fee for this transaction seems unusually high."))
 
-        if self.wallet.has_keystore_encryption():
+        psman = self.wallet.psman
+        if (self.wallet.has_keystore_encryption()
+                or (psman.is_hw_ks
+                and psman.is_ps_ks_inputs_in_tx(tx)
+                and psman.is_ps_ks_encrypted())):
             msg.append("")
             msg.append(_("Enter your password to proceed"))
             password = self.password_dialog('\n'.join(msg))
@@ -1968,6 +2022,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.sign_tx_with_password(tx, sign_done, password)
 
     @protected
+    @ps_ks_protected
     def sign_tx(self, tx, callback, password):
         self.sign_tx_with_password(tx, callback, password)
 
@@ -2000,7 +2055,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
                                         f' txids: {", ".join(wfl.tx_order)}')
 
     @protected_with_parent
-    def create_new_denoms_wfl_from_gui(self, coins, password):
+    def create_new_denoms_wfl_from_gui(self, coins, parent, password):
         psman = self.wallet.psman
         return psman.create_new_denoms_wfl_from_gui(coins, password)
 
@@ -2020,9 +2075,15 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
                                         f' txids: {", ".join(wfl.tx_order)}')
 
     @protected_with_parent
-    def create_new_collateral_wfl_from_gui(self, coins, password):
+    def create_new_collateral_wfl_from_gui(self, coins, parent, password):
         psman = self.wallet.psman
         return psman.create_new_collateral_wfl_from_gui(coins, password)
+
+    @protected_with_parent
+    def send_funds_to_main_ks(self, parent, password):
+        psman = self.wallet.psman
+        tx = psman.prepare_funds_from_ps_keystorere(password)
+        show_transaction(tx, self)
 
     def sign_tx_with_password(self, tx, callback, password):
         '''Sign the transaction in a separate thread.  When done, calls
@@ -2284,9 +2345,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             return self.pay_from
         else:
             include_ps = (min_rounds is None)
+            psman = self.wallet.psman
+            main_ks = psman.ps_keystore and psman.is_hw_ks
             return self.wallet.get_spendable_coins(None, self.config,
                                                    include_ps=include_ps,
-                                                   min_rounds=min_rounds)
+                                                   min_rounds=min_rounds,
+                                                   main_ks=main_ks)
 
     def hide_extra_payload(self):
         self.extra_payload.hide()
@@ -2316,12 +2380,15 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         if run_hook('abort_send', self):  # This and extra fee hooks added for
             return                        # code consistency (trustedcoin only)
         wallet = self.wallet
+        psman = wallet.psman
         is_ps = self.ps_cb.isChecked()
-        min_rounds = None if not is_ps else wallet.psman.mix_rounds
+        min_rounds = None if not is_ps else psman.mix_rounds
         include_ps = (min_rounds is None)
+        main_ks = psman.ps_keystore and psman.is_hw_ks
         inputs = wallet.get_spendable_coins(None, self.config,
                                             include_ps=include_ps,
-                                            min_rounds=min_rounds)
+                                            min_rounds=min_rounds,
+                                            main_ks=main_ks)
         if inputs:
             addr = self.wallet.dummy_address()
             outputs = [TxOutput(TYPE_ADDRESS, addr, '!')]
@@ -2521,7 +2588,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         sb.addPermanentWidget(self.dash_net_button)
 
         self.ps_button = StatusBarButton(read_QIcon('privatesend.png'),
-                                         '', lambda: show_ps_dialog(self))
+                                         '',
+                                         lambda: show_ps_dialog_or_wizard(self))
         self.update_ps_status_btn(False)
         sb.addPermanentWidget(self.ps_button)
 
@@ -2670,6 +2738,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self._delete_wallet()
 
     @protected
+    @ps_ks_protected
     def _delete_wallet(self, password):
         wallet_path = self.wallet.storage.path
         basename = os.path.basename(wallet_path)
@@ -2703,6 +2772,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         d.exec_()
 
     @protected
+    @ps_ks_protected
     def show_private_key(self, address, password):
         if not address:
             return
@@ -2738,6 +2808,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
                _('The operation is undefined. Not just in Dash Electrum, but in general.')
 
     @protected
+    @ps_ks_protected
     def do_sign(self, address, message, signature, password):
         address  = address.text().strip()
         message = message.toPlainText().strip()
@@ -2826,6 +2897,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         d.exec_()
 
     @protected
+    @ps_ks_protected
     def do_decrypt(self, message_e, pubkey_e, encrypted_e, password):
         if self.wallet.is_watching_only():
             self.show_message(_('This is a watching-only wallet.'))
@@ -2976,8 +3048,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             tx = transaction.Transaction(raw_tx)
             self.show_transaction(tx)
 
-    @protected
-    def export_privkeys_dialog(self, password):
+    @protected_with_parent
+    def export_privkeys_dialog(self, parent, password, ps_ks_only=False):
         if self.wallet.is_watching_only():
             self.show_message(_("This is a watching-only wallet"))
             return
@@ -2986,7 +3058,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self.show_message(_('WARNING: This is a multi-signature wallet.') + '\n' +
                               _('It cannot be "backed up" by simply exporting these private keys.'))
 
-        d = WindowModalDialog(self, _('Private keys'))
+        d = WindowModalDialog(parent, _('Private keys'))
         d.setMinimumSize(980, 300)
         vbox = QVBoxLayout(d)
 
@@ -3010,7 +3082,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
 
         private_keys = {}
         w = self.wallet
-        addresses = w.get_addresses() + w.psman.get_addresses()
+        if ps_ks_only:
+            addresses = w.psman.get_addresses()
+        else:
+            addresses = w.get_addresses() + w.psman.get_addresses()
         done = False
         cancelled = False
         def privkeys_thread():
@@ -3665,6 +3740,22 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         psman = self.wallet.psman
         if psman.state in psman.mixing_running_states:
             if not self.question(psman.WAIT_MIXING_STOP_MSG):
+                event.ignore()
+                return
+        if (psman.is_hw_ks
+                and psman.ps_keystore
+                and psman.show_warn_ps_ks
+                and psman.check_funds_on_ps_keystorere()):
+            warn = _('There are funds left on PrivateSend keystore')
+            q = _('Send all coins to hardware wallet')
+            msg = f'{warn}\n\n{q}?'
+            cb = QCheckBox(_("Don't show this again."))
+            cb.setChecked(psman.show_warn_ps_ks)
+            def on_cb(x):
+                psman.show_warn_ps_ks = (x == Qt.Checked)
+            cb.stateChanged.connect(on_cb)
+            if self.question(msg, checkbox=cb):
+                self.send_funds_to_main_ks(mwin=self, parent=self)
                 event.ignore()
                 return
         if not self.cleaned_up:

--- a/electrum_dash/gui/qt/password_dialog.py
+++ b/electrum_dash/gui/qt/password_dialog.py
@@ -60,7 +60,9 @@ class PasswordLayout(object):
 
     titles = [_("Enter Password"), _("Change Password"), _("Enter Passphrase")]
 
-    def __init__(self, msg, kind, OK_button, wallet=None, force_disable_encrypt_cb=False):
+    def __init__(self, msg, kind, OK_button, wallet=None,
+                 force_disable_encrypt_cb=False,
+                 on_edit_cb=None, has_password=False):
         self.wallet = wallet
 
         self.pw = QLineEdit()
@@ -71,6 +73,8 @@ class PasswordLayout(object):
         self.conf_pw.setEchoMode(2)
         self.kind = kind
         self.OK_button = OK_button
+        self.on_edit_cb = on_edit_cb
+        self.has_password = has_password
 
         vbox = QVBoxLayout()
         label = QLabel(msg + "\n")
@@ -100,7 +104,7 @@ class PasswordLayout(object):
 
             m1 = _('New Password:') if kind == PW_CHANGE else _('Password:')
             msgs = [m1, _('Confirm Password:')]
-            if wallet and wallet.has_password():
+            if wallet and wallet.has_password() or self.has_password:
                 grid.addWidget(QLabel(_('Current Password:')), 0, 0)
                 grid.addWidget(self.pw, 0, 1)
                 lockfile = "lock.png"
@@ -129,7 +133,10 @@ class PasswordLayout(object):
 
         def enable_OK():
             ok = self.new_pw.text() == self.conf_pw.text()
-            OK_button.setEnabled(ok)
+            if self.on_edit_cb:
+                self.on_edit_cb(ok)
+            else:
+                OK_button.setEnabled(ok)
             self.encrypt_cb.setEnabled(ok and bool(self.new_pw.text())
                                        and not force_disable_encrypt_cb)
         self.new_pw.textChanged.connect(enable_OK)

--- a/electrum_dash/gui/qt/privatesend_dialog.py
+++ b/electrum_dash/gui/qt/privatesend_dialog.py
@@ -2,19 +2,28 @@
 
 import time
 
-from PyQt5.QtCore import Qt, QTimer
-from PyQt5.QtGui import QColor, QPainter, QTextCursor, QIcon
+from PyQt5.QtCore import Qt, QTimer, pyqtSlot
+from PyQt5.QtGui import QColor, QPainter, QTextCursor, QIcon, QPixmap
 from PyQt5.QtWidgets import (QPlainTextEdit, QCheckBox, QSpinBox, QVBoxLayout,
                              QPushButton, QLabel, QDialog, QGridLayout,
                              QTabWidget, QWidget, QProgressBar, QHBoxLayout,
                              QMessageBox, QStyle, QStyleOptionSpinBox, QAction,
-                             QApplication)
+                             QApplication, QWizardPage, QWizard, QRadioButton,
+                             QButtonGroup, QGroupBox, QLineEdit)
 
+from electrum_dash import mnemonic
 from electrum_dash.dash_ps import filter_log_line, PSLogSubCat, PSStates
 from electrum_dash.i18n import _
+from electrum_dash.util import InvalidPassword
 
+from .installwizard import MSG_ENTER_PASSWORD
 from .util import (HelpLabel, MessageBoxMixin, read_QIcon, custom_message_box,
-                   ColorScheme)
+                   ColorScheme, icon_path, WindowModalDialog, CloseButton,
+                   Buttons, CancelButton, OkButton)
+from .password_dialog import PasswordLayout, PW_NEW, PW_CHANGE
+from .transaction_dialog import show_transaction
+from .qrtextedit import ShowQRTextEdit
+from .seed_dialog import SeedLayout
 
 
 ps_dialogs = []  # Otherwise python randomly garbage collects the dialogs
@@ -23,7 +32,7 @@ ps_dialogs = []  # Otherwise python randomly garbage collects the dialogs
 def protected_with_parent(func):
     def request_password(self, *args, **kwargs):
         mwin = kwargs.pop('mwin')
-        parent = kwargs.pop('parent')
+        parent = kwargs.get('parent')
         password = None
         while mwin.wallet.has_keystore_encryption():
             password = mwin.password_dialog(parent=parent)
@@ -36,7 +45,21 @@ def protected_with_parent(func):
             except Exception as e:
                 mwin.show_error(str(e), parent=parent)
                 continue
-
+        if password is None:
+            psman = mwin.wallet.psman
+            if not psman.is_hw_ks:
+                return func(self, *args, **kwargs)
+            while psman.is_ps_ks_encrypted():
+                password = mwin.password_dialog(parent=parent)
+                if password is None:
+                    # User cancelled password input
+                    return
+                try:
+                    psman.ps_keystore.check_password(password)
+                    break
+                except Exception as e:
+                    mwin.show_error(str(e), parent=parent)
+                    continue
         kwargs['password'] = password
         return func(self, *args, **kwargs)
     return request_password
@@ -120,6 +143,17 @@ def show_ps_dialog(mwin, d=None):
         ps_dialogs.append(d)
 
 
+def show_ps_dialog_or_wizard(mwin):
+    w = mwin.wallet
+    psman = w.psman
+    if (psman.w_type == 'standard' and psman.is_hw_ks
+            and 'ps_keystore' not in w.db.data):
+        wiz = PSKeystoreWizard(mwin)
+        wiz.open()
+    else:
+        show_ps_dialog(mwin)
+
+
 def hide_ps_dialog(mwin):
     for d in ps_dialogs:
         if d.wallet == mwin.wallet:
@@ -144,6 +178,50 @@ class WarnLabel(HelpLabel):
         text = f'{self.help_text}\n\n'
         custom_message_box(icon=QMessageBox.Warning, parent=self,
                            title=_('Warning'), text=text, checkbox=cb)
+
+
+class ShowPSKsSeedDlg(WindowModalDialog):
+
+    def __init__(self, parent, seed, passphrase):
+        WindowModalDialog.__init__(self, parent, ('Dash Electrum - %s %s' %
+                                                  (_('PS Keystore'),
+                                                   _('Seed'))))
+        self.setMinimumWidth(600)
+        vbox = QVBoxLayout(self)
+        title =  _('Your wallet generation seed is:')
+        slayout = SeedLayout(title=title, seed=seed, msg=True,
+                             passphrase=passphrase)
+        vbox.addLayout(slayout)
+        vbox.addLayout(Buttons(CloseButton(self)))
+
+
+class PSKsPasswordDlg(WindowModalDialog):
+
+    def __init__(self, parent, wallet):
+        WindowModalDialog.__init__(self, parent)
+        OK_button = OkButton(self)
+        if not wallet.psman.is_ps_ks_encrypted():
+            msg = _('Your PrivateSend Keystore is not protected.')
+            msg += ' ' + _('Use this dialog to add a password to it.')
+            has_password = False
+        else:
+            msg = _('Your PrivateSend Keystore is password protected.')
+            msg += ' ' + _('Use this dialog to change password on it.')
+            has_password = True
+        self.playout = PasswordLayout(msg=msg, kind=PW_CHANGE,
+                                      OK_button=OK_button,
+                                      has_password=has_password)
+        self.setWindowTitle(self.playout.title())
+        vbox = QVBoxLayout(self)
+        vbox.addLayout(self.playout.layout())
+        vbox.addStretch(1)
+        vbox.addLayout(Buttons(CancelButton(self), OK_button))
+        self.playout.encrypt_cb.hide()
+
+    def run(self):
+        if not self.exec_():
+            return False, None, None
+        return True, self.playout.old_password(), self.playout.new_password()
 
 
 class PSDialogUnsupportedPS(QDialog, MessageBoxMixin):
@@ -208,6 +286,7 @@ class PSDialog(QDialog, MessageBoxMixin):
         self.add_info_tab()
         self.info_update()
         self.info_data_buttons_update()
+        self.add_ps_ks_tab()
         self.add_log_tab()
         self.mwin.ps_signal.connect(self.on_ps_signal)
         self.ps_signal_connected = True
@@ -508,11 +587,12 @@ class PSDialog(QDialog, MessageBoxMixin):
 
     def start_mixing(self, prev_kp_state):
         password = None
-        while self.wallet.has_password():
+        psman = self.psman
+        while self.wallet.has_keystore_encryption():
             password = self.mwin.password_dialog(parent=self)
             if password is None:
                 # User cancelled password input
-                self.psman.keypairs_state = prev_kp_state
+                psman.keypairs_state = prev_kp_state
                 return
             try:
                 self.wallet.check_password(password)
@@ -520,6 +600,19 @@ class PSDialog(QDialog, MessageBoxMixin):
             except Exception as e:
                 self.show_error(str(e))
                 continue
+        if password is None and psman.is_hw_ks:
+            while psman.is_ps_ks_encrypted():
+                password = self.mwin.password_dialog(parent=self)
+                if password is None:
+                    # User cancelled password input
+                    psman.keypairs_state = prev_kp_state
+                    return
+                try:
+                    psman.ps_keystore.check_password(password)
+                    break
+                except Exception as e:
+                    self.show_error(str(e))
+                    continue
         self.wallet.psman.start_mixing(password)
 
     def add_info_tab(self):
@@ -570,6 +663,103 @@ class PSDialog(QDialog, MessageBoxMixin):
         log_vbox.addWidget(clear_log_btn)
         self.log_tab.setLayout(log_vbox)
         self.tabs.addTab(self.log_tab, _('Log'))
+
+    def add_ps_ks_tab(self):
+        psman = self.psman
+        if not psman.is_hw_ks:
+            return
+        self.ps_ks_tab = QWidget()
+        grid = QGridLayout()
+        self.ps_ks_tab.setLayout(grid)
+
+        grid.addWidget(QLabel(_('Master Public Key')), 0, 0)
+        mpk = psman.ps_keystore.get_master_public_key()
+        mpk_text = ShowQRTextEdit()
+        mpk_text.setMaximumHeight(150)
+        mpk_text.addCopyButton(self.mwin.app)
+        mpk_text.setText(mpk)
+        grid.addWidget(mpk_text, 1, 0)
+        grid.setRowStretch(2, 1)
+
+        self.seed_btn = QPushButton(_('Show Seed'))
+
+        def show_ps_ks_seed_dlg():
+            self.show_ps_ks_seed_dialog(mwin=self.mwin, parent=self)
+
+        self.seed_btn.clicked.connect(show_ps_ks_seed_dlg)
+        grid.addWidget(self.seed_btn, 3, 0)
+
+        if psman.is_ps_ks_encrypted():
+            pwd_btn_text = _('Change Password')
+        else:
+            pwd_btn_text = _('Set Password')
+        self.password_btn = QPushButton(pwd_btn_text)
+        self.password_btn.clicked.connect(self.change_ps_ks_password_dialog)
+        grid.addWidget(self.password_btn, 4, 0)
+
+        self.export_privk_btn = QPushButton(_('Export Private Keys'))
+
+        def export_ps_ks_privkeys_dlg():
+            self.mwin.export_privkeys_dialog(ps_ks_only=True, mwin=self.mwin,
+                                             parent=self)
+
+        self.export_privk_btn.clicked.connect(export_ps_ks_privkeys_dlg)
+        grid.addWidget(self.export_privk_btn, 5, 0)
+
+        if psman.is_hw_ks:
+            send_funds_to_main_txt = _('Send all coins to hardware wallet')
+        else:
+            send_funds_to_main_txt = _('Send all coins to main keystore')
+        self.send_funds_to_main_btn = QPushButton(send_funds_to_main_txt)
+
+        def send_funds_to_main_ks():
+            self.mwin.send_funds_to_main_ks(mwin=self.mwin, parent=self)
+
+        self.send_funds_to_main_btn.clicked.connect(send_funds_to_main_ks)
+        grid.addWidget(self.send_funds_to_main_btn, 6, 0)
+
+
+        warn_ps_ks_cb = QCheckBox(psman.warn_ps_ks_data())
+        warn_ps_ks_cb.setChecked(psman.show_warn_ps_ks)
+
+        def on_warn_ps_ks_changed(x):
+            psman.show_warn_ps_ks = (x == Qt.Checked)
+        warn_ps_ks_cb.stateChanged.connect(on_warn_ps_ks_changed)
+        grid.addWidget(warn_ps_ks_cb, 7, 0)
+
+        self.tabs.addTab(self.ps_ks_tab, _('PS Keystore'))
+
+    @protected_with_parent
+    def show_ps_ks_seed_dialog(self, parent, password):
+        psman = self.psman
+        seed = psman.ps_keystore.get_seed(password)
+        passphrase = psman.ps_keystore.get_passphrase(password)
+        d = ShowPSKsSeedDlg(parent, seed, passphrase)
+        d.exec_()
+
+    def change_ps_ks_password_dialog(self):
+        psman = self.psman
+        d = PSKsPasswordDlg(self, self.wallet)
+        ok, old_password, new_password = d.run()
+        if not ok:
+            return
+        try:
+            psman.update_ps_ks_password(old_password, new_password)
+        except InvalidPassword as e:
+            self.show_error(str(e))
+            return
+        except BaseException:
+            self.logger.exception('Failed to update PS Keystore password')
+            self.show_error(_('Failed to update PS Keystore password'))
+            return
+        if psman.is_ps_ks_encrypted():
+            msg = _('Password was updated successfully')
+            pwd_btn_text = _('Change Password')
+        else:
+            msg = _('Password is disabled, this wallet is not protected')
+            pwd_btn_text = _('Set Password')
+        self.show_message(msg, title=_("Success"))
+        self.password_btn.setText(pwd_btn_text)
 
     def update_mixing_status(self):
         psman = self.psman
@@ -651,3 +841,347 @@ class PSDialog(QDialog, MessageBoxMixin):
     def clear_log(self):
         self.log_view.clear()
         self.log_handler.clear_log()
+
+
+class SeedOperationWizardPage(QWizardPage):
+
+    def __init__(self, parent=None):
+        super(SeedOperationWizardPage, self).__init__(parent)
+        self.parent = parent
+        self.setTitle(_('PrivateSend Kestore'))
+        self.setSubTitle(_('Do you want to create a new seed, or to'
+                           ' restore a wallet using an existing seed?'))
+
+        self.rb_create = QRadioButton(_('Create a new seed'))
+        self.rb_restore = QRadioButton(_('I already have a seed'))
+        self.rb_create.setChecked(True)
+        self.button_group = QButtonGroup()
+        self.button_group.addButton(self.rb_create)
+        self.button_group.addButton(self.rb_restore)
+        gb_vbox = QVBoxLayout()
+        gb_vbox.addWidget(self.rb_create)
+        gb_vbox.addWidget(self.rb_restore)
+        self.gb_create = QGroupBox(_('Select operation type'))
+        self.gb_create.setLayout(gb_vbox)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.gb_create)
+        self.setLayout(layout)
+
+    def nextId(self):
+        if self.rb_create.isChecked():
+            return self.parent.CREATE_SEED_PAGE
+        else:
+            return self.parent.ENTER_SEED_PAGE
+
+
+class CreateSeedWizardPage(QWizardPage):
+
+    def __init__(self, parent=None):
+        super(CreateSeedWizardPage, self).__init__(parent)
+        self.parent = parent
+        self.setTitle(_('PrivateSend Kestore Seed'))
+        self.setSubTitle(_('Your wallet generation seed is:'))
+        self.layout = QVBoxLayout()
+        self.setLayout(self.layout)
+        self.main_widget = QWidget()
+        self.layout.addWidget(self.main_widget)
+
+    def initializePage(self):
+        self.layout.removeWidget(self.main_widget)
+        self.main_widget.setParent(None)
+        self.main_widget = QWidget()
+        self.layout.addWidget(self.main_widget)
+
+        self.parent.seed_text = mnemonic.Mnemonic('en').make_seed('standard')
+        self.slayout = SeedLayout(seed=self.parent.seed_text, msg=True,
+                                  options=['ext'])
+        self.main_widget.setLayout(self.slayout)
+
+    def nextId(self):
+        if self.slayout.is_ext:
+            return self.parent.REQUEST_PASS_PAGE
+        else:
+            return self.parent.CONFIRM_SEED_PAGE
+
+    def validatePage(self):
+        self.parent.is_ext = self.slayout.is_ext
+        self.parent.is_restore = False
+        return True
+
+
+class RequestPassphraseWizardPage(QWizardPage):
+
+    def __init__(self, parent=None):
+        super(RequestPassphraseWizardPage, self).__init__(parent)
+        self.parent = parent
+        self.setTitle(_('Seed extension'))
+        subtitle = '\n'.join([
+            _('You may extend your seed with custom words.'),
+            _('Your seed extension must be saved together with your seed.'),
+        ])
+        self.setSubTitle(subtitle)
+
+        self.pass_edit = QLineEdit()
+        warning = '\n'.join([
+            _('Note that this is NOT your encryption password.'),
+            _('If you do not know what this is, leave this field empty.'),
+        ])
+        warn_label = QLabel(warning)
+        layout = QVBoxLayout()
+        layout.addWidget(self.pass_edit)
+        layout.addWidget(warn_label)
+        self.setLayout(layout)
+
+    def nextId(self):
+        if self.parent.is_restore:
+            return self.parent.KEYSTORE_PWD_PAGE
+        else:
+            return self.parent.CONFIRM_SEED_PAGE
+
+    def validatePage(self):
+        self.parent.seed_ext_text = self.pass_edit.text()
+        return True
+
+
+class ConfirmSeedWizardPage(QWizardPage):
+
+    def __init__(self, parent=None):
+        super(ConfirmSeedWizardPage, self).__init__(parent)
+        self.parent = parent
+        self.setTitle(_('Confirm Seed'))
+        subtitle = ' '.join([
+            _('Your seed is important!'),
+            _('If you lose your seed, your money will be permanently lost.'),
+            _('To make sure that you have properly saved your seed,'
+              ' please retype it here.')
+        ])
+        self.setSubTitle(subtitle)
+        self.layout = QVBoxLayout()
+        self.setLayout(self.layout)
+        self.main_widget = QWidget()
+        self.layout.addWidget(self.main_widget)
+        self.seed_ok = False
+
+    def initializePage(self):
+        self.layout.removeWidget(self.main_widget)
+        self.main_widget.setParent(None)
+        self.main_widget = QWidget()
+        self.layout.addWidget(self.main_widget)
+
+        self.slayout = SeedLayout(is_seed=lambda x: x == self.parent.seed_text,
+                                  options=[], on_edit_cb=self.set_seed_ok)
+        self.main_widget.setLayout(self.slayout)
+        self.seed_ok = self.slayout.is_seed(self.slayout.get_seed())
+
+    def set_seed_ok(self, seed_ok):
+        self.seed_ok = seed_ok
+        self.completeChanged.emit()
+
+    def nextId(self):
+        if self.parent.is_ext:
+            return self.parent.CONFIRM_PASS_PAGE
+        else:
+            return self.parent.KEYSTORE_PWD_PAGE
+
+    def isComplete(self):
+        return self.seed_ok
+
+
+class ConfirmPassphraseWizardPage(QWizardPage):
+
+    def __init__(self, parent=None):
+        super(ConfirmPassphraseWizardPage, self).__init__(parent)
+        self.parent = parent
+        self.setTitle(_('Confirm Seed Extension'))
+        message = '\n'.join([
+            _('Your seed extension must be saved together with your seed.'),
+            _('Please type it here.'),
+        ])
+        self.setSubTitle(message)
+        layout = QVBoxLayout()
+        self.pass_edit = QLineEdit()
+        self.pass_edit.textChanged.connect(self.on_pass_edit_changed)
+        layout.addWidget(self.pass_edit)
+        self.setLayout(layout)
+
+    @pyqtSlot()
+    def on_pass_edit_changed(self):
+        self.completeChanged.emit()
+
+    def nextId(self):
+        return self.parent.KEYSTORE_PWD_PAGE
+
+    def isComplete(self):
+        return self.pass_edit.text() == self.parent.seed_ext_text
+
+
+class EnterSeedWizardPage(QWizardPage):
+
+    def __init__(self, parent=None):
+        super(EnterSeedWizardPage, self).__init__(parent)
+        self.parent = parent
+        self.setTitle(_('Enter Seed'))
+        subtitle = _('Please enter your seed phrase in order'
+                     ' to restore your wallet.')
+        self.setSubTitle(subtitle)
+        self.layout = QVBoxLayout()
+        self.setLayout(self.layout)
+        self.main_widget = QWidget()
+        self.layout.addWidget(self.main_widget)
+        self.seed_ok = False
+
+    def initializePage(self):
+        self.layout.removeWidget(self.main_widget)
+        self.main_widget.setParent(None)
+        self.main_widget = QWidget()
+        self.layout.addWidget(self.main_widget)
+
+        self.slayout = SeedLayout(is_seed=mnemonic.is_seed,
+                                  options=['ext'], on_edit_cb=self.set_seed_ok)
+        self.main_widget.setLayout(self.slayout)
+        self.seed_ok = self.slayout.is_seed(self.slayout.get_seed())
+
+    def set_seed_ok(self, seed_ok):
+        self.seed_ok = seed_ok
+        self.completeChanged.emit()
+
+    def nextId(self):
+        if self.slayout.is_ext:
+            return self.parent.REQUEST_PASS_PAGE
+        else:
+            return self.parent.KEYSTORE_PWD_PAGE
+
+    def isComplete(self):
+        return self.seed_ok
+
+    def validatePage(self):
+        self.parent.seed_text = self.slayout.get_seed()
+        self.parent.is_ext = self.slayout.is_ext
+        self.parent.is_restore = True
+        return True
+
+
+class PSKeysotrePasswdWizardPage(QWizardPage):
+
+    def __init__(self, parent=None):
+        super(PSKeysotrePasswdWizardPage, self).__init__(parent)
+        self.parent = parent
+        self.setTitle(_('Encrypt PrivateSend Keystore'))
+        self.setSubTitle('Set password for PrivateSend keystore encryption')
+        self.layout = QVBoxLayout()
+        self.setLayout(self.layout)
+        self.main_widget = QWidget()
+        self.layout.addWidget(self.main_widget)
+        self.passwd_ok = False
+
+    def initializePage(self):
+        self.layout.removeWidget(self.main_widget)
+        self.main_widget.setParent(None)
+        self.main_widget = QWidget()
+        self.layout.addWidget(self.main_widget)
+
+        self.playout = PasswordLayout(msg=MSG_ENTER_PASSWORD, kind=PW_NEW,
+                                      OK_button=None,
+                                      on_edit_cb=self.set_passwd_ok)
+        self.playout.encrypt_cb.hide()
+        self.main_widget.setLayout(self.playout.layout())
+        self.passwd_ok = \
+            self.playout.new_pw.text() == self.playout.conf_pw.text()
+
+    def set_passwd_ok(self, passwd_ok):
+        self.passwd_ok = passwd_ok
+        self.completeChanged.emit()
+
+    def nextId(self):
+        return self.parent.DONE_KEYSTORE_PAGE
+
+    def isComplete(self):
+        return self.passwd_ok
+
+    def validatePage(self):
+        self.parent.keystore_password = self.playout.new_password()
+        return True
+
+
+class DonePSKeysotreWizardPage(QWizardPage):
+
+    def __init__(self, parent=None):
+        super(DonePSKeysotreWizardPage, self).__init__(parent)
+        self.parent = parent
+        self.setTitle(_('Done'))
+        self.setSubTitle(_('PrivateSend Kestore Created'))
+
+
+        layout = QVBoxLayout()
+        self.err_lbl = QLabel()
+        self.err_lbl.setObjectName('err-label')
+        self.err_lbl.hide()
+        layout.addWidget(self.err_lbl)
+        self.seed_lbl = QLabel()
+        layout.addWidget(self.seed_lbl)
+        self.seed_ext_lbl = QLabel()
+        layout.addWidget(self.seed_ext_lbl)
+        self.setLayout(layout)
+
+    def initializePage(self):
+        seed_text = self.parent.seed_text
+        is_ext = self.parent.is_ext
+        seed_ext_text = self.parent.seed_ext_text
+        keystore_password = self.parent.keystore_password
+
+        try:
+            psman = self.parent.wallet.psman
+            psman.create_ps_ks_from_seed_ext_password(seed_text, seed_ext_text,
+                                                      keystore_password)
+            seed_lbl_text = '%s: %s' % (_('Seed'), seed_text)
+            self.seed_lbl.setText(seed_lbl_text)
+            if is_ext:
+                seed_ext_lbl_text = '%s: %s' % (_('Seed Extension'),
+                                                seed_ext_text)
+                self.seed_ext_lbl.setText(seed_ext_lbl_text)
+            else:
+                self.seed_ext_lbl.setText('')
+        except Exception as e:
+            self.err_lbl.setText(f'Error: {str(e)}')
+            self.err_lbl.show()
+
+
+class PSKeystoreWizard(QWizard):
+
+    SEED_OPERATION_PAGE = 1
+    CREATE_SEED_PAGE = 2
+    REQUEST_PASS_PAGE = 3
+    CONFIRM_SEED_PAGE = 4
+    CONFIRM_PASS_PAGE = 5
+    ENTER_SEED_PAGE = 6
+    KEYSTORE_PWD_PAGE = 7
+    DONE_KEYSTORE_PAGE = 8
+
+    def __init__(self, parent):
+        super(PSKeystoreWizard, self).__init__(parent)
+        self.gui = parent
+        self.wallet = parent.wallet
+        self.seed_text = ''
+        self.is_ext = False
+        self.seed_ext_text = ''
+        self.keystore_password = None
+
+        self.setPage(self.SEED_OPERATION_PAGE, SeedOperationWizardPage(self))
+        self.setPage(self.CREATE_SEED_PAGE, CreateSeedWizardPage(self))
+        self.setPage(self.REQUEST_PASS_PAGE, RequestPassphraseWizardPage(self))
+        self.setPage(self.CONFIRM_SEED_PAGE, ConfirmSeedWizardPage(self))
+        self.setPage(self.CONFIRM_PASS_PAGE, ConfirmPassphraseWizardPage(self))
+        self.setPage(self.ENTER_SEED_PAGE, EnterSeedWizardPage(self))
+        self.setPage(self.KEYSTORE_PWD_PAGE, PSKeysotrePasswdWizardPage(self))
+        self.setPage(self.DONE_KEYSTORE_PAGE, DonePSKeysotreWizardPage(self))
+
+        logo = QPixmap(icon_path('privatesend.png'))
+        logo = logo.scaledToWidth(32, mode=Qt.SmoothTransformation)
+        self.setWizardStyle(QWizard.ClassicStyle)
+        self.setOption(QWizard.NoBackButtonOnLastPage, True)
+        self.setOption(QWizard.NoCancelButtonOnLastPage, True)
+        self.setPixmap(QWizard.LogoPixmap, logo)
+        self.setWindowTitle(_('PrivateSend Keystore Wizard'))
+        self.setWindowIcon(read_QIcon('electrum-dash.png'))
+        self.setMinimumSize(800, 450)

--- a/electrum_dash/gui/qt/seed_dialog.py
+++ b/electrum_dash/gui/qt/seed_dialog.py
@@ -90,10 +90,12 @@ class SeedLayout(QVBoxLayout):
         self.is_bip39 = cb_bip39.isChecked() if 'bip39' in self.options else False
 
     def __init__(self, seed=None, title=None, icon=True, msg=None, options=None,
-                 is_seed=None, passphrase=None, parent=None, for_seed_words=True):
+                 is_seed=None, passphrase=None, parent=None,
+                 for_seed_words=True, on_edit_cb=None):
         QVBoxLayout.__init__(self)
         self.parent = parent
         self.options = options
+        self.on_edit_cb = on_edit_cb
         if title:
             self.addWidget(WWLabel(title))
         if seed:  # "read only", we already have the text
@@ -187,7 +189,10 @@ class SeedLayout(QVBoxLayout):
             status = ('checksum: ' + ('ok' if is_checksum else 'failed')) if is_wordlist else 'unknown wordlist'
             label = 'BIP39' + ' (%s)'%status
         self.seed_type_label.setText(label)
-        self.parent.next_button.setEnabled(b)
+        if self.on_edit_cb:
+            self.on_edit_cb(b)
+        else:
+            self.parent.next_button.setEnabled(b)
 
         # disable suggestions if user already typed an unknown word
         for word in self.get_seed().split(" ")[:-1]:

--- a/electrum_dash/keystore.py
+++ b/electrum_dash/keystore.py
@@ -403,7 +403,8 @@ class PS_BIP32_KeyStore(BIP32_KeyStore):
 
     def dump(self):
         d = BIP32_KeyStore.dump(self)
-        d['addr_deriv_offset'] = self.addr_deriv_offset
+        if self.addr_deriv_offset != 1:
+            d['addr_deriv_offset'] = self.addr_deriv_offset
         return d
 
     def derive_pubkey(self, for_change, n):
@@ -415,8 +416,8 @@ class PS_BIP32_KeyStore(BIP32_KeyStore):
         return super().get_xpubkey(derivation, i)
 
     def get_private_key(self, sequence, password):
-        derivation = self.addr_deriv_offset*2 + int(sequence[0])
-        _sequence = (derivation, *sequence[1:])
+        derivation = self.addr_deriv_offset*2 + int(sequence[0] % 2)
+        _sequence = [derivation, *sequence[1:]]
         return super().get_private_key(_sequence, password)
 
 

--- a/electrum_dash/plugins/trezor/qt.py
+++ b/electrum_dash/plugins/trezor/qt.py
@@ -177,6 +177,8 @@ class QtPlugin(QtPluginBase):
     def receive_menu(self, menu, addrs, wallet):
         if len(addrs) != 1:
             return
+        if wallet.psman.is_ps_ks(addrs[0]):
+            return
         for keystore in wallet.get_keystores():
             if type(keystore) == self.keystore_class:
                 def show_address(keystore=keystore):

--- a/electrum_dash/stacktraces.py
+++ b/electrum_dash/stacktraces.py
@@ -164,9 +164,6 @@ class StackTraces(threading.Thread):
                 self._sample(frame)
             if traceback:
                 self._traceback_fn(code, ident, frame)
-        #from pprint import pprint
-        #print('>'*80)
-        #pprint(code)
 
         if traceback:
             self._code = code

--- a/electrum_dash/version.py
+++ b/electrum_dash/version.py
@@ -1,8 +1,8 @@
 import re
 
 
-ELECTRUM_VERSION = '3.3.8.6' # version of the client package
-APK_VERSION = '3.3.8.6'      # read by buildozer.spec
+ELECTRUM_VERSION = '3.3.8.7' # version of the client package
+APK_VERSION = '3.3.8.7'      # read by buildozer.spec
 
 PROTOCOL_VERSION = '1.4.2'   # protocol version requested
 

--- a/electrum_dash/wallet.py
+++ b/electrum_dash/wallet.py
@@ -753,7 +753,10 @@ class Abstract_Wallet(AddressSynchronizer):
             assert is_address(addr), f"not valid Dash address: {addr}"
             # note that change addresses are not necessarily ismine
             # in which case this is a no-op
-            self.check_address(addr)
+            if self.psman.is_ps_ks(addr):
+                self.psman.check_address(addr)
+            else:
+                self.check_address(addr)
         max_change = self.max_change_outputs if self.multiple_change else 1
         return change_addrs[:max_change]
 

--- a/electrum_dash/wallet.py
+++ b/electrum_dash/wallet.py
@@ -464,18 +464,28 @@ class Abstract_Wallet(AddressSynchronizer):
         )
 
     def get_spendable_coins(self, domain, config, *, nonlocal_only=False,
-                            include_ps=False, min_rounds=None, main_ks=False):
+                            include_ps=False, min_rounds=None,
+                            no_ps_data=False, main_ks=False):
         confirmed_only = config.get('confirmed_only', False)
+        get_min_rounds = None if no_ps_data else min_rounds
         utxos = self.get_utxos(domain,
                                excluded_addresses=self.frozen_addresses,
                                mature_only=True,
                                confirmed_only=confirmed_only,
                                nonlocal_only=nonlocal_only,
                                include_ps=include_ps,
-                               min_rounds=min_rounds)
+                               min_rounds=get_min_rounds)
         utxos = [utxo for utxo in utxos if not self.is_frozen_coin(utxo)]
         if main_ks:
             utxos = [utxo for utxo in utxos if not utxo['is_ps_ks']]
+        if no_ps_data:
+            for utxo in utxos:
+                if self.psman.prob_denominate_tx_coin(utxo):
+                    utxo['ps_rounds'] = 0
+            if not include_ps and min_rounds is None:
+                utxos = [utxo for utxo in utxos if utxo['ps_rounds'] is None]
+            elif min_rounds is not None:
+                utxos = [utxo for utxo in utxos if utxo['ps_rounds'] == 0]
         if self.psman.enabled and include_ps and not self.psman.allow_others:
             utxos = [utxo for utxo in utxos
                      if utxo['ps_rounds'] != PSCoinRounds.OTHER]
@@ -764,10 +774,13 @@ class Abstract_Wallet(AddressSynchronizer):
 
     def make_unsigned_transaction(self, coins, outputs, config, fixed_fee=None,
                                   change_addr=None, is_sweep=False,
-                                  min_rounds=None,
+                                  min_rounds=None, no_ps_data=False,
                                   tx_type=0, extra_payload=b''):
         if min_rounds is not None:
-            self.psman.check_min_rounds(coins, min_rounds)
+            if no_ps_data:
+                self.psman.check_min_rounds(coins, 0)
+            else:
+                self.psman.check_min_rounds(coins, min_rounds)
 
         # check outputs
         i_max = None
@@ -807,6 +820,12 @@ class Abstract_Wallet(AddressSynchronizer):
                 tx = coin_chooser.make_tx(coins, [], outputs[:],
                                           change_addrs, fee_estimator,
                                           self.dust_threshold(),
+                                          tx_type=tx_type,
+                                          extra_payload=extra_payload)
+            elif no_ps_data:
+                coin_chooser = coinchooser.get_coin_chooser_privatesend()
+                tx = coin_chooser.make_tx(coins, outputs[:], fee_estimator,
+                                          min_rounds=0,
                                           tx_type=tx_type,
                                           extra_payload=extra_payload)
             else:


### PR DESCRIPTION
- limit dnspython version in contrib/requirements/requirements.txt (on 2.0.0 tests fail)
- fix PS_BIP32_KeyStore
- wallet: fix get_change_addresses_for_new_transaction (if change address is passed as parameter, test if it from ps_keystore)
- remove unused more denominate wfl denom_rounds from log (keep in wfl)
- privatesend: add support to hardware wallets
- remove staled code