### PR TITLE
qt/exchange_rate add bypass Tor for Fiat option

### DIFF
--- a/electrum_dash/exchange_rate.py
+++ b/electrum_dash/exchange_rate.py
@@ -51,6 +51,10 @@ class ExchangeBase(Logger):
         url = ''.join(['https://', site, get_string])
         network = Network.get_instance()
         proxy = network.proxy if network else None
+        if proxy:
+            fiat_bypass_tor = network.config.get('fiat_bypass_tor', False)
+            if fiat_bypass_tor and network.proxy_is_tor(proxy):
+                proxy = None
         async with make_aiohttp_session(proxy) as session:
             async with session.get(url) as response:
                 response.raise_for_status()
@@ -61,6 +65,10 @@ class ExchangeBase(Logger):
         url = ''.join(['https://', site, get_string])
         network = Network.get_instance()
         proxy = network.proxy if network else None
+        if proxy:
+            fiat_bypass_tor = network.config.get('fiat_bypass_tor', False)
+            if fiat_bypass_tor and network.proxy_is_tor(proxy):
+                proxy = None
         async with make_aiohttp_session(proxy) as session:
             async with session.get(url) as response:
                 response.raise_for_status()

--- a/electrum_dash/gui/qt/network_dialog.py
+++ b/electrum_dash/gui/qt/network_dialog.py
@@ -295,6 +295,12 @@ class NetworkChoiceLayout(object):
         self.tor_auto_on_cb.setChecked(self.config.get('tor_auto_on', True))
         self.tor_auto_on_cb.clicked.connect(self.use_tor_auto_on)
 
+        self.fiat_bypass_tor_cb = QCheckBox(_('Bypass Tor proxy for Fiat'
+                                              ' rates loading'))
+        fiat_bypass_tor = self.config.get('fiat_bypass_tor', False)
+        self.fiat_bypass_tor_cb.setChecked(fiat_bypass_tor)
+        self.fiat_bypass_tor_cb.clicked.connect(self.fiat_bypass_tor)
+
         grid.addWidget(self.tor_cb, 1, 0, 1, 3)
         grid.addWidget(self.proxy_cb, 2, 0, 1, 3)
         grid.addWidget(HelpButton(_('Proxy settings apply to all connections: with Dash Electrum servers, but also with third-party services.')), 2, 4)
@@ -305,7 +311,8 @@ class NetworkChoiceLayout(object):
         grid.addWidget(self.proxy_password, 5, 3)
         grid.addWidget(self.tor_auto_on_cb, 6, 0, 1, 3)
         grid.addWidget(HelpButton(_('During wallet startup try to detect and use Tor Proxy.')), 6, 4)
-        grid.setRowStretch(7, 1)
+        grid.addWidget(self.fiat_bypass_tor_cb, 7, 0, 1, 3)
+        grid.setRowStretch(8, 1)
 
         # Blockchain Tab
         grid = QGridLayout(blockchain_tab)
@@ -519,6 +526,11 @@ class NetworkChoiceLayout(object):
             self.proxy_cb.setChecked(True)
         self.check_disable_proxy(use_it)
         self.set_proxy()
+
+    def fiat_bypass_tor(self, bypass):
+        self.config.set_key('fiat_bypass_tor', bypass, False)
+        coro = self.network.restart()
+        self.network.run_from_another_thread(coro)
 
     def proxy_settings_changed(self):
         self.tor_cb.setChecked(False)


### PR DESCRIPTION
- allow bypass Tor proxy for Fiat rates/history loading
- add Network/Proxy tab checkbox "Bypass Tor proxy for Fiat rates loading" (default off)

![Screenshot from 2020-08-04 13-51-11](https://user-images.githubusercontent.com/992125/89285722-93e65280-d659-11ea-9743-baeacb33478d.png)
