### PR TITLE
kivy: add fiat bypass tor to electrum net settings

### DIFF
--- a/electrum_dash/gui/kivy/main_window.py
+++ b/electrum_dash/gui/kivy/main_window.py
@@ -124,6 +124,15 @@ class ElectrumWindow(App):
         self.tor_auto_on_bp = not self.electrum_config.get('tor_auto_on', True)
         self.electrum_config.set_key('tor_auto_on', self.tor_auto_on_bp, True)
 
+    fiat_bypass_tor_bp = BooleanProperty()
+    def toggle_fiat_bypass_tor(self, x):
+        self.fiat_bypass_tor_bp = \
+            not self.electrum_config.get('fiat_bypass_tor', False)
+        self.electrum_config.set_key('fiat_bypass_tor',
+                                     self.fiat_bypass_tor_bp, True)
+        coro = self.network.restart()
+        self.network.run_from_another_thread(coro)
+
     proxy_str = StringProperty('')
     def update_proxy_str(self, proxy: dict):
         mode = proxy.get('mode')

--- a/electrum_dash/gui/kivy/uix/ui_screens/network.kv
+++ b/electrum_dash/gui/kivy/uix/ui_screens/network.kv
@@ -36,6 +36,12 @@ Popup:
 
                 CardSeparator
                 SettingsItem:
+                    title: f'{app.network.FIAT_BYPASS_TOR_MSG}: ' + ('ON' if app.fiat_bypass_tor_bp else 'OFF')
+                    description: _('Do not use Tor proxy for Fiat rates network calls')
+                    action: app.toggle_fiat_bypass_tor
+
+                CardSeparator
+                SettingsItem:
                     title: _("Auto-connect") + ': ' + ('ON' if app.auto_connect else 'OFF')
                     description: _("Select your server automatically")
                     action: app.toggle_auto_connect

--- a/electrum_dash/gui/qt/network_dialog.py
+++ b/electrum_dash/gui/qt/network_dialog.py
@@ -295,8 +295,7 @@ class NetworkChoiceLayout(object):
         self.tor_auto_on_cb.setChecked(self.config.get('tor_auto_on', True))
         self.tor_auto_on_cb.clicked.connect(self.use_tor_auto_on)
 
-        self.fiat_bypass_tor_cb = QCheckBox(_('Bypass Tor proxy for Fiat'
-                                              ' rates loading'))
+        self.fiat_bypass_tor_cb = QCheckBox(self.network.FIAT_BYPASS_TOR_MSG)
         fiat_bypass_tor = self.config.get('fiat_bypass_tor', False)
         self.fiat_bypass_tor_cb.setChecked(fiat_bypass_tor)
         self.fiat_bypass_tor_cb.clicked.connect(self.fiat_bypass_tor)

--- a/electrum_dash/network.py
+++ b/electrum_dash/network.py
@@ -241,6 +241,7 @@ class Network(Logger):
     TOR_WARN_MSG_KIVY = f'{TOR_WARN_MSG} {TOR_DOCS_URI_KIVY}'
     TOR_WARN_MSG_TXT = f'{TOR_WARN_MSG}\n{TOR_DOCS_URI}'
     TOR_AUTO_ON_MSG = _('Detect Tor proxy on wallet startup')
+    FIAT_BYPASS_TOR_MSG = _('Bypass Tor proxy for Fiat rates loading')
 
     def __init__(self, config: SimpleConfig=None):
         global INSTANCE


### PR DESCRIPTION
- kivy: add fiat bypass tor option to electrum network popup

![Screenshot from 2020-08-04 16-20-15](https://user-images.githubusercontent.com/992125/89299251-10cff700-d66f-11ea-848e-609370ae8926.png)
