### PR TITLE
PS: fix keypairs calc on small/zero funds

### DIFF
--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -2951,8 +2951,8 @@ class PSManager(Logger):
                             mature_only=True)
         coins = [c for c in coins if not w.is_frozen_coin(c)]
         coins_val = sum([c['value'] for c in coins])
-        if coins_val < MIN_DENOM_VAL:  # no coins to create denoms
-            return []
+        if coins_val < MIN_DENOM_VAL and not on_keep_amount:
+            return []  # no coins to create denoms
 
         in_cnt = len(coins)
         approx_val = need_val - old_denoms_val

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -2596,6 +2596,7 @@ class PSManager(Logger):
                             and self.is_hw_ks):
                         await group.spawn(self._prepare_funds_from_hw_wallet())
                     await group.spawn(self._make_keypairs_cache(password))
+                    await group.spawn(self._check_not_enough_funds())
                     await group.spawn(self._check_all_mixed())
                     await group.spawn(self._maintain_pay_collateral_tx())
                     await group.spawn(self._maintain_collateral_amount())
@@ -2684,6 +2685,13 @@ class PSManager(Logger):
             if self.all_mixed:
                 await self.stop_mixing_from_async_thread(self.ALL_MIXED_MSG,
                                                          'inf')
+
+    async def _check_not_enough_funds(self):
+        while not self.main_taskgroup.closed():
+            if self._not_enough_funds:
+                await asyncio.sleep(30)
+                self._not_enough_funds = False
+            await asyncio.sleep(5)
 
     async def _maintain_pay_collateral_tx(self):
         kp_wait_state = KPStates.Ready if self.need_password() else None

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -942,14 +942,18 @@ class PSManager(Logger):
 
     @property
     def is_waiting(self):
-        is_mixing = (self.state in self.mixing_running_states)
+        if self.state not in self.mixing_running_states:
+            return False
+        if self.keypairs_state in [KPStates.NeedCache, KPStates.Caching]:
+            return False
+
         active_wfls_cnt = 0
         active_wfls_cnt += len(self.denominate_wfl_list)
         if self.new_denoms_wfl:
             active_wfls_cnt += 1
         if self.new_collateral_wfl:
             active_wfls_cnt += 1
-        return is_mixing and active_wfls_cnt == 0
+        return (active_wfls_cnt == 0)
 
     @state.setter
     def state(self, state):

--- a/electrum_dash/gui/kivy/main_window.py
+++ b/electrum_dash/gui/kivy/main_window.py
@@ -847,7 +847,8 @@ class ElectrumWindow(App):
             wallet = args[0]
             if wallet == self.wallet:
                 self._trigger_update_wallet()
-        elif event in ['ps-state-changes', 'ps-wfl-changes']:
+        elif event in ['ps-state-changes', 'ps-wfl-changes',
+                       'ps-keypairs-changes']:
             wallet, msg, msg_type = (*args, None, None)[:3]
             if wallet == self.wallet:
                 self.update_ps_btn(is_mixing, is_waiting)
@@ -956,6 +957,7 @@ class ElectrumWindow(App):
                                              'ps-not-enough-sm-denoms',
                                              'ps-other-coins-arrived',
                                              'ps-wfl-changes',
+                                             'ps-keypairs-changes',
                                              'ps-state-changes'])
         self.wallet_name = wallet.basename()
         self.update_wallet()

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -440,7 +440,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             wallet = args[0]
             if wallet == self.wallet:
                 self.need_update.set()
-        elif event in ['ps-state-changes', 'ps-wfl-changes']:
+        elif event in ['ps-state-changes', 'ps-wfl-changes',
+                       'ps-keypairs-changes']:
             wallet, msg, msg_type = (*args, None, None)[:3]
             if wallet == self.wallet:
                 self.update_ps_status_btn(is_mixing, is_waiting)

--- a/electrum_dash/tests/test_dash_ps.py
+++ b/electrum_dash/tests/test_dash_ps.py
@@ -1845,9 +1845,9 @@ class PSWalletTestCase(TestCaseForTestnet):
         two_dash_amnts_val = 200142001
 
         res = psman.calc_need_denoms_amounts()
-        assert sum([sum(amnts)for amnts in res])== two_dash_amnts_val
+        assert sum([sum(amnts)for amnts in res]) == two_dash_amnts_val
         res = psman.calc_need_denoms_amounts(on_keep_amount=True)
-        assert sum([sum(amnts)for amnts in res])== two_dash_amnts_val
+        assert sum([sum(amnts)for amnts in res]) == two_dash_amnts_val
 
         # test with spendable amount < keep_amount
         coins0 = w.get_utxos(None, excluded_addresses=w.frozen_addresses,
@@ -1862,9 +1862,18 @@ class PSWalletTestCase(TestCaseForTestnet):
         assert sum([c['value'] for c in coins]) == 50000000  # 0.5 Dash
 
         res = psman.calc_need_denoms_amounts()
-        assert sum([sum(amnts)for amnts in res])== 49840498
+        assert sum([sum(amnts)for amnts in res]) == 49840498
         res = psman.calc_need_denoms_amounts(on_keep_amount=True)
-        assert sum([sum(amnts)for amnts in res])== two_dash_amnts_val
+        assert sum([sum(amnts)for amnts in res]) == two_dash_amnts_val
+
+        # test with zero spendable amount
+        w.set_frozen_state_of_coins(coins, True)
+        coins = [c for c in coins if not w.is_frozen_coin(c)]
+
+        res = psman.calc_need_denoms_amounts()
+        assert sum([sum(amnts)for amnts in res]) == 0
+        res = psman.calc_need_denoms_amounts(on_keep_amount=True)
+        assert sum([sum(amnts)for amnts in res]) == two_dash_amnts_val
 
     def test_calc_tx_size(self):
         # average sizes

--- a/electrum_dash/tests/test_dash_ps.py
+++ b/electrum_dash/tests/test_dash_ps.py
@@ -784,6 +784,13 @@ class PSWalletTestCase(TestCaseForTestnet):
         psman.clear_denominate_wfl('uuid')
         assert psman.is_waiting
 
+        psman.keypairs_state = KPStates.Empty
+        assert psman.is_waiting
+        psman.keypairs_state = KPStates.NeedCache
+        assert not psman.is_waiting
+        psman.keypairs_state = KPStates.Caching
+        assert not psman.is_waiting
+
     def test_get_change_addresses_for_new_transaction(self):
         w = self.wallet
         psman = w.psman


### PR DESCRIPTION
- fix _calc_total_need_val to not modify `outupts_amounts` input param, instead return possilby modified value
- modify keyparis caching for small funds available (need to cache more keys to support multiple new denoms txs, max 5 for now)
- fix caching if zero funds available
- do not try create new denoms/collateral workflows if no funds available
- add _check_not_enough_funds to reset `not_enough_funds` condition on periodical intervals, not only when wallet updated
- when keypairs in state NeedCache/Caching is_waiting is False now