### PR TITLE
Post 4.x PrivateSend fixes

### DIFF
--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -163,7 +163,8 @@ DEFAULT_SUBSCRIBE_SPENT = False
 DEFAULT_ALLOW_OTHERS = False
 
 POOL_MIN_PARTICIPANTS = 3
-POOL_MAX_PARTICIPANTS = 5
+POOL_MIN_PARTICIPANTS_TESTNET = 2
+POOL_MAX_PARTICIPANTS = 20
 
 PRIVATESEND_QUEUE_TIMEOUT = 30
 PRIVATESEND_SESSION_MSG_TIMEOUT = 40
@@ -1359,6 +1360,17 @@ class PSManager(Logger):
             return MAX_MIX_ROUNDS_TESTNET
         else:
             return MAX_MIX_ROUNDS
+
+    @property
+    def pool_min_participants(self):
+        if constants.net.TESTNET:
+            return POOL_MIN_PARTICIPANTS_TESTNET
+        else:
+            return POOL_MIN_PARTICIPANTS
+
+    @property
+    def pool_max_participants(self):
+        return POOL_MAX_PARTICIPANTS
 
     def mix_rounds_data(self, full_txt=False):
         if full_txt:
@@ -5009,9 +5021,9 @@ class PSManager(Logger):
          icnt, mine_icnt, others_icnt, ocnt, op_return_ocnt) = io_values
         if icnt != ocnt:
             return 'Transaction has different count of inputs/outputs'
-        if icnt < POOL_MIN_PARTICIPANTS:
+        if icnt < self.pool_min_participants:
             return 'Transaction has too small count of inputs/outputs'
-        if icnt > POOL_MAX_PARTICIPANTS * PRIVATESEND_ENTRY_MAX_SIZE:
+        if icnt > self.pool_max_participants * PRIVATESEND_ENTRY_MAX_SIZE:
             return 'Transaction has too many count of inputs/outputs'
         if mine_icnt < 1:
             return 'Transaction has too small count of mine inputs'

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -13,6 +13,7 @@ from math import floor, ceil
 from uuid import uuid4
 
 from . import constants, util
+from .bip32 import convert_bip32_intpath_to_strpath
 from .bitcoin import (COIN, address_to_script,
                       is_address, pubkey_to_address)
 from .dash_tx import (STANDARD_TX, PSTxTypes, SPEC_TX_NAMES, PSCoinRounds,
@@ -1080,6 +1081,15 @@ class PSManager(Logger):
         if addr and bool(idx):
             if addr != self.derive_address(*idx):
                 raise PSKsInternalAddressCorruption()
+
+    def get_address_path_str(self, address):
+        intpath = self.get_address_index(address)
+        if intpath is None:
+            return None
+        if self.ps_keystore:
+            addr_deriv_offset = self.ps_keystore.addr_deriv_offset
+            intpath = (addr_deriv_offset*2 + intpath[0], intpath[1])
+        return convert_bip32_intpath_to_strpath(intpath)
 
     def create_new_address(self, for_change=False):
         assert type(for_change) is bool

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -2499,6 +2499,7 @@ class PSManager(Logger):
                 tx.add_info_from_wallet(self.wallet)
             keypairs = self.get_keypairs()
             signed_txins_cnt = tx.sign(keypairs)
+            tx.finalize_psbt()
             keypairs.clear()
             if mine_txins_cnt is None:
                 mine_txins_cnt = len(tx.inputs())
@@ -3210,8 +3211,6 @@ class PSManager(Logger):
             if tx and tx.is_complete():
                 return tx
         except BaseException as e:
-            import traceback
-            traceback.print_exc()
             self.logger.wfl_err(f'prepare_funds_from_hw_wallet: {str(e)}')
 
     async def _prepare_funds_from_hw_wallet(self):
@@ -3257,9 +3256,7 @@ class PSManager(Logger):
 
     def check_funds_on_ps_keystore(self):
         w = self.wallet
-        coins = w.get_utxos(None, excluded_addresses=w.frozen_addresses,
-                            mature_only=True, include_ps=True)
-        coins = [c for c in coins if not w.is_frozen_coin(c)]
+        coins = w.get_utxos(None, mature_only=True, include_ps=True)
         ps_ks_coins = [c for c in coins if c.is_ps_ks]
         if ps_ks_coins:
             return True

--- a/electrum_dash/gui/kivy/uix/dialogs/password_dialog.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/password_dialog.py
@@ -219,6 +219,7 @@ class AbstractPasswordDialog(Factory.Popup):
                 return True
         else:
             if self.on_success:
+                self.ids.textinput_generic_password.focus = False
                 args = (self.pw, self.new_password) if self.is_change else (self.pw,)
                 Clock.schedule_once(lambda dt: self.on_success(*args), 0.1)
 

--- a/electrum_dash/gui/qt/address_list.py
+++ b/electrum_dash/gui/qt/address_list.py
@@ -132,7 +132,7 @@ class AddressModel(QAbstractItemModel, Logger):
         self.wallet = self.parent.wallet
         self.addr_items = list()
         # setup bg thread to get updated data
-        self.data_ready.connect(self.on_get_data, Qt.BlockingQueuedConnection)
+        self.data_ready.connect(self.on_get_data, Qt.QueuedConnection)
         self.get_data_thread = GetDataThread(self, self.get_addresses,
                                              self.data_ready, self)
         self.get_data_thread.start()

--- a/electrum_dash/gui/qt/history_list.py
+++ b/electrum_dash/gui/qt/history_list.py
@@ -119,7 +119,7 @@ class HistoryModel(QAbstractItemModel, Logger):
         self.tx_group_expand_icn = read_QIcon('tx_group_expand.png')
         self.tx_group_collapse_icn = read_QIcon('tx_group_collapse.png')
         # setup bg thread to get updated data
-        self.data_ready.connect(self.on_get_data, Qt.BlockingQueuedConnection)
+        self.data_ready.connect(self.on_get_data, Qt.QueuedConnection)
         self.get_data_thread = GetDataThread(self, self.get_history_data,
                                              self.data_ready, self)
         self.get_data_thread.data_call_args = (self.group_ps, )

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -2032,7 +2032,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         try:
             tx_list = psman.prepare_funds_from_ps_keystore(password)
             for tx in tx_list:
-                show_transaction(tx, self)
+                show_transaction(tx, parent=self)
         except Exception as e:
             self.show_error(f'{str(e)}')
 

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -3227,7 +3227,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self.show_warning(_('Please restart Dash Electrum to activate the new GUI settings'), title=_('Success'))
 
     def closeEvent(self, event):
-        # It seems in some rare cases this closeEvent() is called twice
         psman = self.wallet.psman
         if psman.state in psman.mixing_running_states and not psman.is_waiting:
             if not self.question(psman.WAIT_MIXING_STOP_MSG):
@@ -3249,13 +3248,20 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
                 self.send_funds_to_main_ks(mwin=self, parent=self)
                 event.ignore()
                 return
-        self.history_list.hm.get_data_thread.stop()
-        self.address_list.am.get_data_thread.stop()
-        self.utxo_list.cm.get_data_thread.stop()
+        # It seems in some rare cases this closeEvent() is called twice
         if not self.cleaned_up:
+            self.stop_get_data_threads()
             self.cleaned_up = True
             self.clean_up()
         event.accept()
+
+    def stop_get_data_threads(self):
+        self.history_list.hm.get_data_thread.stop()
+        self.address_list.am.get_data_thread.stop()
+        self.utxo_list.cm.get_data_thread.stop()
+        self.history_list.hm.get_data_thread.wait()
+        self.address_list.am.get_data_thread.wait()
+        self.utxo_list.cm.get_data_thread.wait()
 
     def clean_up(self):
         hide_ps_dialog(self)

--- a/electrum_dash/gui/qt/privatesend_dialog.py
+++ b/electrum_dash/gui/qt/privatesend_dialog.py
@@ -21,7 +21,6 @@ from .util import (HelpLabel, MessageBoxMixin, read_QIcon, custom_message_box,
                    ColorScheme, icon_path, WindowModalDialog, CloseButton,
                    Buttons, CancelButton, OkButton)
 from .password_dialog import PasswordLayout, PW_NEW, PW_CHANGE
-from .transaction_dialog import show_transaction
 from .qrtextedit import ShowQRTextEdit
 from .seed_dialog import SeedLayout
 

--- a/electrum_dash/gui/qt/protx_wizards.py
+++ b/electrum_dash/gui/qt/protx_wizards.py
@@ -784,7 +784,7 @@ class SaveDip3WizardPage(QWizardPage):
             ownership = (_('This wallet is owns on new Masternode '
                            '(external operator)'))
         elif new_mn.is_operated:
-            ownership = (_('This wallet is operates on new Masternode'))
+            ownership = (_('This wallet is the operator on the new Masternode'))
         else:
             ownership = _('None')
         self.ownership.setText(ownership)

--- a/electrum_dash/gui/qt/util.py
+++ b/electrum_dash/gui/qt/util.py
@@ -952,7 +952,8 @@ class GetDataThread(QThread):
                 self.need_update.clear()
                 self.res = self.data_call(*self.data_call_args)
                 try:
-                    self.data_ready_sig.emit()
+                    if not self.stopping:
+                        self.data_ready_sig.emit()
                 except AttributeError:
                     pass  # data_ready signal is already unbound on gui close
             except BaseException as e:
@@ -963,7 +964,6 @@ class GetDataThread(QThread):
     def stop(self):
         self.stopping = True
         self.need_update.set()
-        self.wait(0)
 
 
 def import_meta_gui(electrum_window, title, importer, on_success):

--- a/electrum_dash/gui/qt/utxo_list.py
+++ b/electrum_dash/gui/qt/utxo_list.py
@@ -118,7 +118,7 @@ class UTXOModel(QAbstractItemModel, Logger):
         self.wallet = self.parent.wallet
         self.coin_items = list()
         # setup bg thread to get updated data
-        self.data_ready.connect(self.on_get_data, Qt.BlockingQueuedConnection)
+        self.data_ready.connect(self.on_get_data, Qt.QueuedConnection)
         self.get_data_thread = GetDataThread(self, self.get_coins,
                                              self.data_ready, self)
         self.get_data_thread.start()

--- a/electrum_dash/plugins/keepkey/keepkey.py
+++ b/electrum_dash/plugins/keepkey/keepkey.py
@@ -447,7 +447,7 @@ class KeepKeyPlugin(HW_PluginBase):
             address = txout.address
             use_create_by_derivation = False
 
-            if txout.is_mine and not has_change:
+            if txout.is_mine and not txout.is_ps_ks and not has_change:
                 # prioritise hiding outputs on the 'change' branch from user
                 # because no more than one change address allowed
                 if txout.is_change == any_output_on_change_branch:

--- a/electrum_dash/plugins/safe_t/safe_t.py
+++ b/electrum_dash/plugins/safe_t/safe_t.py
@@ -417,7 +417,7 @@ class SafeTPlugin(HW_PluginBase):
             address = txout.address
             use_create_by_derivation = False
 
-            if txout.is_mine and not has_change:
+            if txout.is_mine and not txout.is_ps_ks and not has_change:
                 # prioritise hiding outputs on the 'change' branch from user
                 # because no more than one change address allowed
                 # note: ^ restriction can be removed once we require fw

--- a/electrum_dash/plugins/trezor/trezor.py
+++ b/electrum_dash/plugins/trezor/trezor.py
@@ -456,7 +456,7 @@ class TrezorPlugin(HW_PluginBase):
             address = txout.address
             use_create_by_derivation = False
 
-            if txout.is_mine and not has_change:
+            if txout.is_mine and not txout.is_ps_ks and not has_change:
                 # prioritise hiding outputs on the 'change' branch from user
                 # because no more than one change address allowed
                 # note: ^ restriction can be removed once we require fw

--- a/electrum_dash/tests/test_dash_ps.py
+++ b/electrum_dash/tests/test_dash_ps.py
@@ -3154,40 +3154,6 @@ class PSWalletTestCase(TestCaseForTestnet):
         filtered_line = filter_log_line(test_line % w.dummy_address())
         assert filtered_line == test_line % FILTERED_ADDR
 
-    def test_is_mine_lookahead(self):
-        w = self.wallet
-        psman = w.psman
-
-        last_recv_addr = w.db.get_receiving_addresses(slice_start=-1)[0]
-        last_recv_index = w.get_address_index(last_recv_addr)[1]
-        last_change_addr = w.db.get_change_addresses(slice_start=-1)[0]
-        last_change_index = w.get_address_index(last_change_addr)[1]
-
-        not_in_wallet_recv_addrs = []
-        for ri in range(last_recv_index + 1, last_recv_index + 101):
-            sequence = [0, ri]
-            generated_addr = w.derive_address(0, ri)
-            assert not w.is_mine(generated_addr)
-            not_in_wallet_recv_addrs.append(generated_addr)
-
-        not_in_wallet_change_addrs = []
-        for ci in range(last_change_index + 1, last_change_index + 101):
-            sequence = [1, ci]
-            generated_addr = w.derive_address(1, ci)
-            assert not w.is_mine(generated_addr)
-            not_in_wallet_change_addrs.append(generated_addr)
-
-        assert psman._is_mine_lookahead(not_in_wallet_recv_addrs[9])
-
-        assert psman._is_mine_lookahead(not_in_wallet_change_addrs[9],
-                                   for_change=True)
-
-        for addr in not_in_wallet_recv_addrs:
-            assert psman._is_mine_lookahead(addr)
-
-        for addr in not_in_wallet_change_addrs:
-            assert psman._is_mine_lookahead(addr, for_change=True)
-
     def test_calc_denoms_by_values(self):
         w = self.wallet
         psman = w.psman

--- a/electrum_dash/tests/test_dash_ps.py
+++ b/electrum_dash/tests/test_dash_ps.py
@@ -95,6 +95,7 @@ class PSWalletTestCase(TestCaseForTestnet):
         psman = self.wallet.psman
         psman.state = PSStates.Ready
         psman.loop = asyncio.get_event_loop()
+        psman.can_find_untracked = lambda: True
 
     def tearDown(self):
         super(PSWalletTestCase, self).tearDown()

--- a/electrum_dash/transaction.py
+++ b/electrum_dash/transaction.py
@@ -1252,6 +1252,7 @@ class PartialTxOutput(TxOutput, PSBTSection):
         self.pubkeys = []  # type: List[bytes]  # note: order matters
         self.is_mine = False  # type: bool  # whether the wallet considers the output to be ismine
         self.is_change = False  # type: bool  # whether the wallet considers the output to be change
+        self.is_ps_ks = False # type: Optional[bool]  # is PS keystore for TXO
 
     def to_json(self):
         d = super().to_json()

--- a/electrum_dash/version.py
+++ b/electrum_dash/version.py
@@ -1,7 +1,7 @@
 import re
 
 
-ELECTRUM_VERSION = '4.0.4.0' # version of the client package
+ELECTRUM_VERSION = '4.0.4.0rc6' # version of the client package
 APK_VERSION = '4.0.4.0'      # read by buildozer.spec
 
 PROTOCOL_VERSION = '1.4.2'   # protocol version requested

--- a/electrum_dash/wallet.py
+++ b/electrum_dash/wallet.py
@@ -2347,9 +2347,8 @@ class Deterministic_Wallet(Abstract_Wallet):
 
     def get_address_path_str(self, address, ps_ks=False):
         if ps_ks:
-            intpath = self.psman.get_address_index(address)
-        else:
-            intpath = self.get_address_index(address)
+            return self.psman.get_address_path_str(address)
+        intpath = self.get_address_index(address)
         if intpath is None:
             return None
         return convert_bip32_intpath_to_strpath(intpath)

--- a/electrum_dash/wallet.py
+++ b/electrum_dash/wallet.py
@@ -1387,6 +1387,7 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
                              else self.get_txin_type(address))
         txout.is_mine = True
         txout.is_change = self.is_change(address)
+        txout.is_ps_ks = ps_ks
         if isinstance(self, Multisig_Wallet):
             txout.num_sig = self.m
         self._add_txinout_derivation_info(txout, address,


### PR DESCRIPTION
- kivy: unfocus passwd field in passwd dlg on_dismiss (to fix back button behaviour)
- fix typo in qt/protx_wizards.py
- qt: fix GetDataThread finishing/waiting
- ps keystore: real derivation for get_address_path_str
- fix dash_ps POOL_MIN/MAX_PARTICIPANTS
- psman: remove _is_mine_lookahead
- psman: add can_find_untracked (to do find untracked when wallet is fully synced)
- psman: additional check for mine in/outs on denominate tx
- fixes for PS on HW wallets
- assorted fixes related to PS
- version to 4.0.4.0rc6