### PR TITLE
Big sur fix qt version

### DIFF
--- a/contrib/dash/travis/travis-build-osx.sh
+++ b/contrib/dash/travis/travis-build-osx.sh
@@ -45,6 +45,9 @@ $PIP_CMD install --no-dependencies -I x11_hash>=1.4
 $PIP_CMD install --no-dependencies -I \
     -r contrib/deterministic-build/requirements-mac-build.txt
 
+# Fix to work with macOS Big Sur
+$PIP_CMD install -I PyQt5==5.13.1
+
 pushd electrum_dash
 git clone https://github.com/zebra-lucky/electrum-dash-locale/ locale-repo
 mv locale-repo/locale .

--- a/electrum_dash/version.py
+++ b/electrum_dash/version.py
@@ -1,8 +1,8 @@
 import re
 
 
-ELECTRUM_VERSION = '4.0.4.0rc6' # version of the client package
-APK_VERSION = '4.0.4.0'      # read by buildozer.spec
+ELECTRUM_VERSION = '4.0.4.1' # version of the client package
+APK_VERSION = '4.0.4.1'      # read by buildozer.spec
 
 PROTOCOL_VERSION = '1.4.2'   # protocol version requested
 


### PR DESCRIPTION
- Downgrade PyQt5 version to fix macOS Big Sur problems
- version to 4.0.4.1