### PR TITLE
PS: option to group mix origin coins by address

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,3 +1,17 @@
+# Release 4.0.9.2
+
+ * qt: fix PayToEdit.parse_amount (#172)
+ * gui qt/kivy: add ProTx/LLMQ reset UI (#173)
+ * PS: separate new denoms/collateral txins by address (#175)
+ * qt PS Dialog: fix PS Keystore tab (#176)
+ * various DIP3 fixes (post 4.0.9.1) (#177)
+ * util.py: fix mainnet Dash.org block explorer (#180)
+ * paymentrequest: check network on PaymentRequest parse (#182)
+ * qt: fix protected_with_parent decorator (#183)
+ * GUI: fix send Payment msg from qt/kivy gui, do not broadcast tx
+   when sending Payment to Anypay (#185)
+
+
 # Release 4.0.9.1
  * Fix Transaction.input_script for size estimation (#166)
  * Fix android startup crash (#167)

--- a/electrum_dash/address_synchronizer.py
+++ b/electrum_dash/address_synchronizer.py
@@ -908,7 +908,8 @@ class AddressSynchronizer(Logger):
     def get_addr_outputs(self, address: str) -> Dict[TxOutpoint, PartialTxInput]:
         coins, spent = self.get_addr_io(address)
         out = {}
-        if self.psman.enabled:
+        psman = self.psman
+        if psman.enabled:
             ps_origin_addrs = self.db.get_ps_origin_addrs()
         else:
             ps_origin_addrs = []
@@ -921,9 +922,11 @@ class AddressSynchronizer(Logger):
                 ps_collateral = self.db.get_ps_collateral(prevout_str)
                 if ps_collateral:
                     ps_rounds = int(PSCoinRounds.COLLATERAL)
-            if ps_rounds is None and ps_origin_addrs:
-                if address in ps_origin_addrs:
-                    ps_rounds = int(PSCoinRounds.MIX_ORIGIN)
+            if (psman.group_origin_coins_by_addr
+                    and ps_rounds is None
+                    and ps_origin_addrs
+                    and address in ps_origin_addrs):
+                ps_rounds = int(PSCoinRounds.MIX_ORIGIN)
             if ps_rounds is None:
                 ps_other = self.db.get_ps_other(prevout_str)
                 if ps_other:

--- a/electrum_dash/coinchooser.py
+++ b/electrum_dash/coinchooser.py
@@ -139,9 +139,9 @@ class CoinChooserBase(Logger):
                     if ps_rounds >= 0:  # denoms
                         max_rounds = max(max_rounds, ps_rounds)
                     else:
-                        # do not spend ps_collateral/ps_other if possible
-                        # and therefore set max_rounds to maximum
-                        max_rounds = 1e9
+                        # do not spend ps_collateral/ps_origin_addrs/ps_other
+                        # if possible and therefore set max_rounds to maximum
+                        max_rounds = 1e9 - ps_rounds
             assert min_height is not None
             # the fee estimator is typically either a constant or a linear function,
             # so the "function:" effective_value(bucket) will be homomorphic for addition

--- a/electrum_dash/dash_msg.py
+++ b/electrum_dash/dash_msg.py
@@ -182,6 +182,7 @@ class DSMessageIDs(IntEnumWithCheck):
     MSG_NOERR = 0x13
     MSG_SUCCESS = 0x14
     MSG_ENTRIES_ADDED = 0x15
+    ERR_SIZE_MISMATCH = 0x16
 
 
 DS_MSG_STR = {
@@ -211,6 +212,7 @@ DS_MSG_STR = {
     int(DSMessageIDs.MSG_NOERR): _('No errors detected.'),
     int(DSMessageIDs.MSG_SUCCESS): _('Transaction created successfully.'),
     int(DSMessageIDs.MSG_ENTRIES_ADDED): _('Your entries added successfully.'),
+    int(DSMessageIDs.ERR_SIZE_MISMATCH): _('Inputs vs outputs size mismatch.'),
 }
 
 

--- a/electrum_dash/dash_msg.py
+++ b/electrum_dash/dash_msg.py
@@ -133,7 +133,6 @@ class DSPoolState(IntEnumWithCheck):
     ACCEPTING_ENTRIES = 2
     SIGNING = 3
     ERROR = 4
-    SUCCESS = 5
 
 
 DS_POOL_STATE_STR = {
@@ -142,7 +141,6 @@ DS_POOL_STATE_STR = {
     int(DSPoolState.ACCEPTING_ENTRIES): _('ACCEPTING_ENTRIES'),
     int(DSPoolState.SIGNING): _('SIGNING'),
     int(DSPoolState.ERROR): _('ERROR'),
-    int(DSPoolState.SUCCESS): _('SUCCESS'),
 }
 
 

--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -3081,7 +3081,6 @@ class PSManager(Logger):
         coins_cnt = len(coins)
         denoms_amounts = []
         denoms_val = 0
-        denoms_cnt = 0
         approx_found = False
 
         while not approx_found:
@@ -3097,7 +3096,6 @@ class PSManager(Logger):
                     max_total = min_total - COLLATERAL_VAL + MAX_COLLATERAL_VAL
                     if min_total < coins_val:
                         denoms_val += dval
-                        denoms_cnt += 1
                         cur_approx_amounts.append(dval)
                         if max_total > coins_val:
                             approx_found = True

--- a/electrum_dash/dash_tx.py
+++ b/electrum_dash/dash_tx.py
@@ -888,13 +888,6 @@ SPEC_TX_NAMES = {
 }
 
 
-class PSCoinRounds(IntEnum):
-    '''PS Tx types'''
-    MINUSINF = -1e9
-    OTHER = -2
-    COLLATERAL = -1
-
-
 def read_extra_payload(vds, tx_type):
     if tx_type:
         extra_payload_size = vds.read_compact_size()

--- a/electrum_dash/gui/kivy/uix/dialogs/coins_dialog.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/coins_dialog.py
@@ -7,8 +7,8 @@ from kivy.uix.recycleview.views import RecycleDataViewBehavior
 from kivy.uix.recycleboxlayout import RecycleBoxLayout
 from kivy.uix.behaviors import FocusBehavior
 
-from electrum_dash.dash_ps import sort_utxos_by_ps_rounds
-from electrum_dash.dash_tx import PSCoinRounds
+from electrum_dash.dash_ps import (PSCoinRounds, ps_coin_rounds_str,
+                                   sort_utxos_by_ps_rounds)
 from electrum_dash.gui.kivy.i18n import _
 from electrum_dash.gui.kivy.uix.context_menu import ContextMenu
 
@@ -212,12 +212,8 @@ class CoinsDialog(Factory.Popup):
         ci['block_height'] = str(height)
         if ps_rounds is None:
             ci['ps_rounds'] = 'N/A'
-        elif ps_rounds == PSCoinRounds.OTHER:
-            ci['ps_rounds'] = 'Other'
-        elif ps_rounds == PSCoinRounds.COLLATERAL:
-            ci['ps_rounds'] = 'Collateral'
         else:
-            ci['ps_rounds'] = str(ps_rounds)
+            ci['ps_rounds'] = ps_coin_rounds_str(ps_rounds)
         ci['ps_rounds_orig'] = ps_rounds
         ci['prev_h'] = prev_h
         ci['prev_n'] = prev_n

--- a/electrum_dash/gui/kivy/uix/dialogs/coins_dialog.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/coins_dialog.py
@@ -280,7 +280,7 @@ class CoinsDialog(Factory.Popup):
         r = coins[0].ps_rounds
         if r is None:
             return
-        if r == PSCoinRounds.OTHER or r >= 0:
+        if r in [PSCoinRounds.OTHER, PSCoinRounds.MIX_ORIGIN] or r >= 0:
             coin_value = coins[0].value_sats()
             if coin_value >= psman.min_new_denoms_from_coins_val:
                 cmenu = [(_('Create New Denoms'), self.create_new_denoms)]

--- a/electrum_dash/gui/kivy/uix/dialogs/privatesend.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/privatesend.py
@@ -319,6 +319,12 @@ Builder.load_string('''
                 action: root.show_kp_timeout_popup
             CardSeparator
             SettingsItem:
+                value: ': ON' if root.group_origin else ': OFF'
+                title: root.group_origin_text + self.value
+                description: root.group_origin_help
+                action: root.toggle_group_origin
+            CardSeparator
+            SettingsItem:
                 value: ': ON' if root.group_history else ': OFF'
                 title: root.group_history_text + self.value
                 description: root.group_history_help
@@ -617,6 +623,7 @@ class PSMixingTab(BoxLayout):
     mix_prog = NumericProperty()
     dn_balance = StringProperty()
     ps_balance = StringProperty()
+    group_origin = BooleanProperty()
     group_history = BooleanProperty()
     subscribe_spent = BooleanProperty()
     allow_others = BooleanProperty()
@@ -657,6 +664,10 @@ class PSMixingTab(BoxLayout):
         self.create_sm_denoms_text = psman.create_sm_denoms_data()
         self.create_sm_denoms_help = psman.create_sm_denoms_data(full_txt=True)
 
+        self.group_origin_text = psman.group_origin_coins_by_addr_data()
+        self.group_origin_help = \
+            psman.group_origin_coins_by_addr_data(full_txt=True)
+
         self.group_history_text = psman.group_history_data()
         self.group_history_help = psman.group_history_data(full_txt=True)
 
@@ -684,6 +695,7 @@ class PSMixingTab(BoxLayout):
         self.ps_balance = app.format_amount_and_units(val)
         val = sum(wallet.get_balance(include_ps=False, min_rounds=0))
         self.dn_balance = app.format_amount_and_units(val)
+        self.group_origin = psman.group_origin_coins_by_addr
         self.group_history = psman.group_history
         self.subscribe_spent = psman.subscribe_spent
         self.allow_others = psman.allow_others
@@ -785,6 +797,11 @@ class PSMixingTab(BoxLayout):
                     self.app.create_small_denoms(denoms_by_vals)
             d = Question(q, on_q_answered)
             d.open()
+
+    def toggle_group_origin(self, *args):
+        self.psman.group_origin_coins_by_addr = \
+            not self.psman.group_origin_coins_by_addr
+        self.group_origin = self.psman.group_origin_coins_by_addr
 
     def toggle_group_history(self, *args):
         self.psman.group_history = not self.psman.group_history

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -53,7 +53,7 @@ from electrum_dash import (keystore, ecc, constants, util, bitcoin, commands,
                            paymentrequest)
 from electrum_dash.base_crash_reporter import BaseCrashReporter
 from electrum_dash.bitcoin import COIN, is_address
-from electrum_dash.dash_tx import DashTxError, PSCoinRounds
+from electrum_dash.dash_tx import DashTxError
 from electrum_dash.plugin import run_hook, BasePlugin
 from electrum_dash.i18n import _
 from electrum_dash.util import (format_time,

--- a/electrum_dash/gui/qt/privatesend_dialog.py
+++ b/electrum_dash/gui/qt/privatesend_dialog.py
@@ -525,6 +525,18 @@ class PSDialog(QDialog, MessageBoxMixin):
         grid.addWidget(kp_timeout_label, i, 0)
         grid.addWidget(self.kp_timeout_sb, i, 2)
 
+        # group_origin_coins_by_addr
+        cb_txt = psman.group_origin_coins_by_addr_data(full_txt=True)
+        group_origin_cb = QCheckBox(cb_txt)
+        group_origin_cb.setChecked(psman.group_origin_coins_by_addr)
+
+        def on_group_origin_state_changed(x):
+            psman.group_origin_coins_by_addr = (x == Qt.Checked)
+        group_origin_cb.stateChanged.connect(on_group_origin_state_changed)
+
+        i = grid.rowCount()
+        grid.addWidget(group_origin_cb, i, 0, 1, -1)
+
         # group_history
         group_hist_cb = QCheckBox(psman.group_history_data(full_txt=True))
         group_hist_cb.setChecked(psman.group_history)

--- a/electrum_dash/gui/qt/privatesend_dialog.py
+++ b/electrum_dash/gui/qt/privatesend_dialog.py
@@ -532,6 +532,7 @@ class PSDialog(QDialog, MessageBoxMixin):
 
         def on_group_origin_state_changed(x):
             psman.group_origin_coins_by_addr = (x == Qt.Checked)
+            self.mwin.utxo_list.update()
         group_origin_cb.stateChanged.connect(on_group_origin_state_changed)
 
         i = grid.rowCount()

--- a/electrum_dash/gui/qt/utxo_list.py
+++ b/electrum_dash/gui/qt/utxo_list.py
@@ -493,7 +493,9 @@ class UTXOList(MyTreeView):
             txid = utxo.prevout.txid.hex()
             outpoint = utxo.prevout.to_str()
             if (ps_rounds is not None
-                    and (ps_rounds == PSCoinRounds.OTHER or ps_rounds >= 0)):
+                    and (ps_rounds in [PSCoinRounds.OTHER,
+                                       PSCoinRounds.MIX_ORIGIN]
+                         or ps_rounds >= 0)):
                 coin_val = utxo.value_sats()
                 mwin = self.parent
                 if coin_val >= psman.min_new_denoms_from_coins_val:

--- a/electrum_dash/gui/qt/utxo_list.py
+++ b/electrum_dash/gui/qt/utxo_list.py
@@ -35,8 +35,8 @@ from PyQt5.QtWidgets import (QAbstractItemView, QHeaderView, QComboBox,
 
 from electrum_dash.i18n import _
 from electrum_dash.transaction import PartialTxInput
-from electrum_dash.dash_ps import sort_utxos_by_ps_rounds
-from electrum_dash.dash_tx import PSCoinRounds
+from electrum_dash.dash_ps import (PSCoinRounds, sort_utxos_by_ps_rounds,
+                                   ps_coin_rounds_str)
 from electrum_dash.logging import Logger
 from electrum_dash.util import profiler
 
@@ -178,12 +178,8 @@ class UTXOModel(QAbstractItemModel, Logger):
         is_ps_ks = coin_item['is_ps_ks']
         if ps_rounds is None:
             ps_rounds = 'N/A'
-        elif ps_rounds == PSCoinRounds.COLLATERAL:
-            ps_rounds = 'Collateral'
-        elif ps_rounds == PSCoinRounds.OTHER:
-            ps_rounds = 'Other'
         else:
-            ps_rounds = str(ps_rounds)
+            ps_rounds = ps_coin_rounds_str(ps_rounds)
         if (role == self.view.ROLE_CLIPBOARD_DATA
                 and col == UTXOColumns.OUTPOINT):
             return QVariant(outpoint)

--- a/electrum_dash/version.py
+++ b/electrum_dash/version.py
@@ -1,8 +1,8 @@
 import re
 
 
-ELECTRUM_VERSION = '4.0.9.1' # version of the client package
-APK_VERSION = '4.0.9.1'      # read by buildozer.spec
+ELECTRUM_VERSION = '4.0.9.2' # version of the client package
+APK_VERSION = '4.0.9.2'      # read by buildozer.spec
 
 PROTOCOL_VERSION = '1.4.2'   # protocol version requested
 

--- a/electrum_dash/wallet.py
+++ b/electrum_dash/wallet.py
@@ -61,7 +61,7 @@ from .bitcoin import COIN, TYPE_ADDRESS
 from .bitcoin import is_address, address_to_script, is_minikey, relayfee, dust_threshold
 from .crypto import sha256d
 from . import keystore
-from .dash_tx import SPEC_TX_NAMES, PSCoinRounds
+from .dash_tx import SPEC_TX_NAMES
 from .keystore import (load_keystore, Hardware_KeyStore, KeyStore, KeyStoreWithMPK,
                        AddressIndexGeneric, CannotDerivePubkey)
 from .util import multisig_type
@@ -72,7 +72,8 @@ from .transaction import (Transaction, TxInput, UnknownTxinType, TxOutput,
                           PartialTransaction, PartialTxInput, PartialTxOutput, TxOutpoint)
 from .plugin import run_hook
 from .address_synchronizer import (AddressSynchronizer, TX_HEIGHT_LOCAL,
-                                   TX_HEIGHT_UNCONF_PARENT, TX_HEIGHT_UNCONFIRMED)
+                                   TX_HEIGHT_UNCONF_PARENT, TX_HEIGHT_UNCONFIRMED,
+                                   PSCoinRounds)
 from .invoices import Invoice, OnchainInvoice
 from .invoices import PR_PAID, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED, PR_INFLIGHT, PR_TYPE_ONCHAIN
 from .contacts import Contacts

--- a/electrum_dash/wallet_db.py
+++ b/electrum_dash/wallet_db.py
@@ -1198,6 +1198,27 @@ class WalletDB(JsonDB):
     def get_ps_spent_collaterals(self):
         return self.ps_spent_collaterals
 
+    @modifier
+    def add_ps_origin_addrs(self, txid, data):
+        if isinstance(data, (list, tuple)):
+            self.ps_origin_addrs[txid] = data
+        else:
+            self.ps_origin_addrs[txid] = [data]
+
+    @modifier
+    def pop_ps_origin_addrs(self, txid):
+        return self.ps_origin_addrs.pop(txid, None)
+
+    @locked
+    def get_tx_ps_origin_addrs(self, txid):
+        return self.ps_origin_addrs.get(txid)
+
+    @locked
+    def get_ps_origin_addrs(self):
+        return list({addr
+                     for addrs in self.ps_origin_addrs.values()
+                     for addr in addrs})
+
     @locked
     def get_ps_addresses(self, min_rounds=None):
         '''
@@ -1495,6 +1516,7 @@ class WalletDB(JsonDB):
         self.ps_others = self.get_dict('ps_others')  # outpoint -> (addr, val)
         self.ps_spent_others = self.get_dict('ps_spent_others')  # outpoint -> (addr, val)
         self.ps_spent_collaterals = self.get_dict('ps_spent_collaterals')  # outpoint -> (addr, val)
+        self.ps_origin_addrs = self.get_dict('ps_origin_addrs')  # txid -> [addr, ...] new denoms/new collateral inputs
         self.tx_fees = self.get_dict('tx_fees')                  # type: Dict[str, TxFeesValue]
         # scripthash -> set of (outpoint, value)
         self._prevouts_by_scripthash = self.get_dict('prevouts_by_scripthash')  # type: Dict[str, Set[Tuple[str, int]]]
@@ -1536,6 +1558,7 @@ class WalletDB(JsonDB):
         self.ps_collaterals.clear()
         self.ps_spending_collaterals.clear()
         self.ps_spent_collaterals.clear()
+        self.ps_origin_addrs.clear()
         self.ps_denoms.clear()
         self.ps_spending_denoms.clear()
         self.ps_spent_denoms.clear()


### PR DESCRIPTION
- removed deprecatd `DSPoolState.SUCCESS`, added new `DSMessageIDs.ERR_SIZE_MISMATCH`
- Added GUI option "Group origin coins by address" disabled by default.
- New denom/collateral workflows use coins from one address by one tx, when option is enabled.
- When option is enabled add random delay betwen new denom/collateral workflows (30-300 sec).



related to #142