### PR TITLE
various dip3 fixes (post 4.0.9.1)

### DIFF
--- a/electrum_dash/dash_tx.py
+++ b/electrum_dash/dash_tx.py
@@ -335,7 +335,8 @@ class DashProRegTx(ProTxBase):
                 if o.value == 1000 * COIN:
                     found_idx = i
                     break
-            self.collateralOutpoint = TxOutPoint(b'\x00'*32, found_idx)
+            if found_idx >= 0:
+                self.collateralOutpoint = TxOutPoint(b'\x00'*32, found_idx)
 
         outpoints = [TxOutPoint(bfh(i.prevout.txid.hex())[::-1],
                                 i.prevout.out_idx)

--- a/electrum_dash/gui/qt/dash_qt.py
+++ b/electrum_dash/gui/qt/dash_qt.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+from copy import deepcopy
 
 from PyQt5.QtCore import Qt, QRect, QPoint, QSize
 from PyQt5.QtWidgets import (QTabBar, QTextEdit, QStylePainter,
@@ -161,7 +162,9 @@ class ExtraPayloadWidget(QTextEdit):
         self.setText('')
 
     def get_extra_data(self):
-        return self.tx_type, self.extra_payload
+        # possible repeated use of extra_payload instance for
+        # make_unsigned_transaction, so use deepcopy to not interfere
+        return self.tx_type, deepcopy(self.extra_payload)
 
     def set_extra_data(self, tx_type, extra_payload, mn_alias=None):
         self.tx_type, self.extra_payload = tx_type, extra_payload

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -2229,9 +2229,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         for e in [self.payto_e, self.message_e, self.amount_e]:
             e.setText('')
             e.setFrozen(False)
-        self.reset_privatesend()
         self.extra_payload.clear()
         self.hide_extra_payload()
+        self.reset_privatesend()
         self.update_status()
         run_hook('do_clear', self)
 

--- a/electrum_dash/gui/qt/protx_wizards.py
+++ b/electrum_dash/gui/qt/protx_wizards.py
@@ -1587,7 +1587,7 @@ class Dip3MasternodeWizard(QWizard):
                                   'address %s' % c_addr)
 
         if p_addr == o_addr or p_addr == v_addr:
-            raise ValidationError('Payout address must differ from owner'
+            raise ValidationError('Payout address must differ from owner '
                                   'and voting addresses')
 
         keystore = self.wallet.keystore

--- a/electrum_dash/network.py
+++ b/electrum_dash/network.py
@@ -1122,10 +1122,12 @@ class Network(Logger, NetworkRetryManager[ServerAddr]):
             r"Transaction check failed",
             r"bad-version",
         }
+        found_substrings = []
         for substring in dashd_specific_error_messages:
             if substring in server_msg:
-                return substring
-        # otherwise:
+                found_substrings.append(substring)
+        if found_substrings:
+            return sorted(found_substrings, key=lambda x: -len(x))[0]
         return _("Unknown error")
 
     @best_effort_reliable


### PR DESCRIPTION
* DashProRegTx.update_with_tx_data: update index only if output found
* ExtraPayloadWidget.get_extra_data: return copy of extra payload
instance
* Network.sanitize_tx_broadcast_response: find max len suitable msg

* qt: clear extra payload before reset_privatesend (available amount will be recalculated without extra payload)