### PR TITLE
GitHub Actions: modify slack notify action to work with PRs

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -186,16 +186,12 @@ jobs:
           asset_name: Dash-Electrum-${{ steps.set_vars.outputs.pkg_ver }}-setup-win64.exe
           asset_content_type: application/vnd.microsoft.portable-executable
 
-  notify_slack:
-    needs: [create_release, build_osx, build_apk, build_linux_win]
+  upload_notify_artifact:
     runs-on: ubuntu-18.04
     if: always()
-    name: Notify slack
+    name: Upload Notify Artifact
     steps:
-      - name: Notify slack
-        uses: zebra-lucky/actions-js-slackJobsStatus@0.0.1
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Upload Notify Artifact
+        uses: zebra-lucky/actions-js-slackJobsStatus@0.0.2
         with:
-          jobs: ${{ toJson(needs) }}
           gh_ctx: ${{ toJson(github) }}

--- a/.github/workflows/notify_slack.yml
+++ b/.github/workflows/notify_slack.yml
@@ -1,0 +1,22 @@
+name: Notify slack workflow
+
+on:
+  workflow_run:
+    workflows:
+      - Run tests workflow
+      - Build release workflow
+    types:
+      - completed
+
+jobs:
+  notify_slack:
+    runs-on: ubuntu-18.04
+    name: Notify slack
+    steps:
+      - name: Notify slack
+        uses: zebra-lucky/actions-js-slackJobsStatus@0.0.2
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          gh_ctx: ${{ toJson(github) }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Run tests workflow
 
 on:
   push:
@@ -33,16 +33,12 @@ jobs:
         run: |
           tox
 
-  notify_slack:
-    needs: [run_tests]
+  upload_notify_artifact:
     runs-on: ubuntu-18.04
     if: always()
-    name: Notify slack
+    name: Upload Notify Artifact
     steps:
-      - name: Notify slack
-        uses: zebra-lucky/actions-js-slackJobsStatus@0.0.1
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Upload Notify Artifact
+        uses: zebra-lucky/actions-js-slackJobsStatus@0.0.2
         with:
-          jobs: ${{ toJson(needs) }}
           gh_ctx: ${{ toJson(github) }}


### PR DESCRIPTION
Fix notifications for cases where in PRs `secrets.SLACK_WEBHOOK_URL` is not available.