### PR TITLE
GUI: fix send Payment msg from qt/kivy gui

### DIFF
--- a/electrum_dash/gui/kivy/main_window.py
+++ b/electrum_dash/gui/kivy/main_window.py
@@ -1255,8 +1255,13 @@ class ElectrumWindow(App, Logger):
         on_success = run_hook('tc_sign_wrapper', self.wallet, tx, on_success, on_failure) or on_success
         Clock.schedule_once(lambda dt: on_success(tx))
 
-    def _broadcast_thread(self, tx, on_complete):
+    def _broadcast_thread(self, tx, pr, on_complete):
         status = False
+        if pr and pr.has_expired():
+            self.send_screen.payment_request = None
+            status, msg = False, _("Invoice has expired")
+            Clock.schedule_once(lambda dt: on_complete(status, msg))
+            return
         try:
             coro = self.wallet.psman.broadcast_transaction(tx)
             self.network.run_from_another_thread(coro)
@@ -1269,10 +1274,17 @@ class ElectrumWindow(App, Logger):
         except BestEffortRequestFailed as e:
             msg = repr(e)
         else:
+            if pr:
+                self.send_screen.payment_request = None
+                refund_address = self.wallet.get_receiving_address()
+                coro = pr.send_payment_and_receive_paymentack(tx.serialize(), refund_address)
+                fut = asyncio.run_coroutine_threadsafe(coro, self.network.asyncio_loop)
+                ack_status, ack_msg = fut.result(timeout=20)
+                self.logger.info(f"Payment ACK: {ack_status}. Ack message: {ack_msg}")
             status, msg = True, tx.txid()
         Clock.schedule_once(lambda dt: on_complete(status, msg))
 
-    def broadcast(self, tx):
+    def broadcast(self, tx, pr=None):
         def on_complete(ok, msg):
             if ok:
                 self.show_info(_('Payment sent.'))
@@ -1284,7 +1296,7 @@ class ElectrumWindow(App, Logger):
 
         if self.network and self.network.is_connected():
             self.show_info(_('Sending'))
-            threading.Thread(target=self._broadcast_thread, args=(tx, on_complete)).start()
+            threading.Thread(target=self._broadcast_thread, args=(tx, pr, on_complete)).start()
         else:
             self.show_info(_('Cannot broadcast transaction') +
                            ':\n' + _('Electrum network not connected'))

--- a/electrum_dash/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/tx_dialog.py
@@ -125,11 +125,12 @@ class ActionButtonOption(NamedTuple):
 
 class TxDialog(Factory.Popup):
 
-    def __init__(self, app, tx):
+    def __init__(self, app, tx, pr=None):
         Factory.Popup.__init__(self)
         self.app = app  # type: ElectrumWindow
         self.wallet = self.app.wallet
         self.tx = tx  # type: Transaction
+        self.pr = pr
         self._action_button_fn = lambda btn: None
         self.dropdown = None
 
@@ -257,7 +258,7 @@ class TxDialog(Factory.Popup):
     def do_broadcast(self):
         if self.dropdown:
             self.dropdown.dismiss()
-        self.app.broadcast(self.tx)
+        self.app.broadcast(self.tx, self.pr)
 
     def show_qr(self):
         original_raw_tx = str(self.tx)

--- a/electrum_dash/gui/kivy/uix/screens.py
+++ b/electrum_dash/gui/kivy/uix/screens.py
@@ -543,19 +543,20 @@ class SendScreen(CScreen, Logger):
     def send_tx(self, tx, invoice, password):
         if self.app.wallet.has_password() and password is None:
             return
+        pr = self.payment_request
         self.save_invoice(invoice)
         def on_success(tx):
             if tx.is_complete():
-                self.app.broadcast(tx)
+                self.app.broadcast(tx, pr)
             else:
-                self.app.tx_dialog(tx)
+                self.app.tx_dialog(tx, pr)
         def on_failure(error):
             self.app.show_error(error)
         if self.app.wallet.can_sign(tx):
             self.app.show_info("Signing...")
             self.app.sign_tx(tx, password, on_success, on_failure)
         else:
-            self.app.tx_dialog(tx)
+            self.app.tx_dialog(tx, pr)
 
     def clear_invoices_dialog(self):
         invoices = self.app.wallet.get_invoices()

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -1962,10 +1962,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         if cancelled:
             return
         if is_send:
+            pr = self.payment_request
             self.save_pending_invoice()
             def sign_done(success):
                 if success:
-                    self.broadcast_or_show(tx)
+                    self.broadcast_or_show(tx, pr)
             self.sign_tx_with_password(tx, callback=sign_done, password=password,
                                        external_keypairs=external_keypairs)
         else:
@@ -1978,7 +1979,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
                             window=self, is_ps_tx=is_ps_tx)
         d.show()
 
-    def broadcast_or_show(self, tx: Transaction):
+    def broadcast_or_show(self, tx: Transaction,
+                          pr: Optional[paymentrequest.PaymentRequest]):
         if not tx.is_complete():
             self.show_transaction(tx)
             return
@@ -1986,7 +1988,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self.show_error(_("You can't broadcast a transaction without a live network connection."))
             self.show_transaction(tx)
             return
-        self.broadcast_transaction(tx)
+        self.broadcast_transaction(tx, pr)
 
     @protected
     @ps_ks_protected
@@ -2074,11 +2076,11 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         msg = _('Signing transaction...')
         WaitingDialog(self, msg, task, on_success, on_failure)
 
-    def broadcast_transaction(self, tx: Transaction):
+    def broadcast_transaction(self, tx: Transaction,
+                              pr: Optional[paymentrequest.PaymentRequest]):
 
         def broadcast_thread():
             # non-GUI thread
-            pr = self.payment_request
             if pr and pr.has_expired():
                 self.payment_request = None
                 return False, _("Invoice has expired")

--- a/electrum_dash/gui/qt/transaction_dialog.py
+++ b/electrum_dash/gui/qt/transaction_dialog.py
@@ -228,10 +228,11 @@ class BaseTxDialog(QDialog, MessageBoxMixin):
         tx.add_info_from_wallet(self.wallet)
 
     def do_broadcast(self):
+        pr = self.main_window.payment_request
         self.main_window.push_top_level_window(self)
         self.main_window.save_pending_invoice()
         try:
-            self.main_window.broadcast_transaction(self.tx)
+            self.main_window.broadcast_transaction(self.tx, pr)
         finally:
             self.main_window.pop_top_level_window(self)
         self.saved = True

--- a/electrum_dash/paymentrequest.py
+++ b/electrum_dash/paymentrequest.py
@@ -59,6 +59,10 @@ _logger = get_logger(__name__)
 REQUEST_HEADERS = {'Accept': 'application/dash-paymentrequest', 'User-Agent': 'Dash-Electrum'}
 ACK_HEADERS = {'Content-Type':'application/dash-payment','Accept':'application/dash-paymentack','User-Agent':'Dash-Electrum'}
 
+BIP70_NO_BROADCAST_TX_DOMAINS = [
+    'anypayinc.com'
+]
+
 ca_path = certifi.where()
 ca_list = None
 ca_keyID = None
@@ -324,6 +328,18 @@ class PaymentRequest:
                                  f"{repr(e)} text: {error_text_received}")
             return False, error
 
+    @property
+    def need_broadcast_tx(self):
+        pay_url = self.payment_url
+        if not pay_url:
+            return True
+        u = urllib.parse.urlparse(pay_url)
+        if u.scheme not in ['https', 'http']:
+            return True
+        for h in BIP70_NO_BROADCAST_TX_DOMAINS:
+            if u.hostname.endswith(h):
+                return False
+        return True
 
 def make_unsigned_request(req: 'OnchainInvoice'):
     addr = req.get_address()

--- a/electrum_dash/paymentrequest.py
+++ b/electrum_dash/paymentrequest.py
@@ -340,6 +340,8 @@ def make_unsigned_request(req: 'OnchainInvoice'):
     script = bfh(address_to_script(addr))
     outputs = [(script, amount)]
     pd = pb2.PaymentDetails()
+    if constants.net.TESTNET:
+        pd.network = 'test'
     for script, amount in outputs:
         pd.outputs.add(amount=amount, script=script)
     pd.time = time


### PR DESCRIPTION
- make_unsigned_request: set network for testnet (fix testnet `PayServer` usage)
- qt: fix sending Payment msg on tx broadcast
- kivy: fix sending Payment msg on tx broadcast
- add PaymentRequest.need_broadcast_tx property
- qt: check if tx need broadcast on PaymentRequest pay (related #174)
- kivy: check if tx need broadcast on PaymentRequest pay (related #174)