### PR TITLE
Some Kivy post 4.0.9 fixes from upstream

### DIFF
--- a/electrum_dash/base_wizard.py
+++ b/electrum_dash/base_wizard.py
@@ -498,13 +498,13 @@ class BaseWizard(Logger):
         self.opt_ext = True
         is_cosigning_seed = lambda x: mnemonic.seed_type(x) in ['standard']
         test = mnemonic.is_seed if self.wallet_type == 'standard' else is_cosigning_seed
-        self.restore_seed_dialog(run_next=self.on_restore_seed, test=test)
+        f = lambda *args: self.run('on_restore_seed', *args)
+        self.restore_seed_dialog(run_next=f, test=test)
 
     def on_restore_seed(self, seed, is_bip39, is_ext):
         self.seed_type = 'bip39' if is_bip39 else mnemonic.seed_type(seed)
         if self.seed_type == 'bip39':
-            def f(passphrase):
-                self.on_restore_bip39(seed, passphrase)
+            f = lambda passphrase: self.run('on_restore_bip39', seed, passphrase)
             self.passphrase_dialog(run_next=f, is_restoring=True) if is_ext else f('')
         elif self.seed_type in ['standard']:
             f = lambda passphrase: self.run('create_keystore', seed, passphrase)

--- a/electrum_dash/base_wizard.py
+++ b/electrum_dash/base_wizard.py
@@ -690,6 +690,7 @@ class BaseWizard(Logger):
         self.seed_type = seed_type
         seed = mnemonic.Mnemonic('en').make_seed(seed_type=self.seed_type)
         self.opt_bip39 = False
+        self.opt_ext = True
         f = lambda x: self.request_passphrase(seed, x)
         self.show_seed_dialog(run_next=f, seed_text=seed)
 

--- a/electrum_dash/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/installwizard.py
@@ -880,16 +880,18 @@ class RestoreSeedDialog(WizardDialog):
         self.ids.text_input_seed.text = ''
         self.message = _('Please type your seed phrase using the virtual keyboard.')
         self.title = _('Enter Seed')
-        self.ext = False
-        self.bip39 = False
+        self.opt_ext = kwargs['opt_ext']
+        self.opt_bip39 = kwargs['opt_bip39']
+        self.is_ext = False
+        self.is_bip39 = False
 
     def options_dialog(self):
         from .seed_options import SeedOptionsDialog
         def callback(ext, bip39):
-            self.ext = ext
-            self.bip39 = bip39
+            self.is_ext = ext
+            self.is_bip39 = bip39
             self.update_next_button()
-        d = SeedOptionsDialog(self.ext, self.bip39, callback)
+        d = SeedOptionsDialog(self.opt_ext, self.opt_bip39, self.is_ext, self.is_bip39, callback)
         d.open()
 
     def get_suggestions(self, prefix):
@@ -898,7 +900,7 @@ class RestoreSeedDialog(WizardDialog):
                 yield w
 
     def update_next_button(self):
-        self.ids.next.disabled = False if self.bip39 else not bool(self._test(self.get_text()))
+        self.ids.next.disabled = False if self.is_bip39 else not bool(self._test(self.get_text()))
 
     def on_text(self, dt):
         self.update_next_button()
@@ -986,7 +988,7 @@ class RestoreSeedDialog(WizardDialog):
             tis.focus = False
 
     def get_params(self, b):
-        return (self.get_text(), self.bip39, self.ext)
+        return (self.get_text(), self.is_bip39, self.is_ext)
 
 
 class ConfirmSeedDialog(RestoreSeedDialog):
@@ -1100,6 +1102,8 @@ class InstallWizard(BaseWizard, Widget):
         ConfirmSeedDialog(self, **kwargs).open()
 
     def restore_seed_dialog(self, **kwargs):
+        kwargs['opt_bip39'] = self.opt_bip39
+        kwargs['opt_ext'] = self.opt_ext
         RestoreSeedDialog(self, **kwargs).open()
 
     def confirm_dialog(self, **kwargs):

--- a/electrum_dash/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/installwizard.py
@@ -841,11 +841,12 @@ class ChoiceLineDialog(WizardChoiceDialog):
 class ShowSeedDialog(WizardDialog):
     seed_text = StringProperty('')
     message = _("If you forget your PIN or lose your device, your seed phrase will be the only way to recover your funds.")
-    ext = False
 
     def __init__(self, wizard, **kwargs):
         super(ShowSeedDialog, self).__init__(wizard, **kwargs)
         self.seed_text = kwargs['seed_text']
+        self.opt_ext = True
+        self.is_ext = False
 
     def on_parent(self, instance, value):
         if value:
@@ -854,12 +855,12 @@ class ShowSeedDialog(WizardDialog):
     def options_dialog(self):
         from .seed_options import SeedOptionsDialog
         def callback(ext, _):
-            self.ext = ext
-        d = SeedOptionsDialog(self.ext, None, callback)
+            self.is_ext = ext
+        d = SeedOptionsDialog(self.opt_ext, False, self.is_ext, False, callback)
         d.open()
 
     def get_params(self, b):
-        return (self.ext,)
+        return (self.is_ext,)
 
 
 class WordButton(Button):
@@ -1105,6 +1106,8 @@ class InstallWizard(BaseWizard, Widget):
     def confirm_seed_dialog(self, **kwargs):
         kwargs['title'] = _('Confirm Seed')
         kwargs['message'] = _('Please retype your seed phrase, to confirm that you properly saved it')
+        kwargs['opt_bip39'] = self.opt_bip39
+        kwargs['opt_ext'] = self.opt_ext
         ConfirmSeedDialog(self, **kwargs).open()
 
     def restore_seed_dialog(self, **kwargs):

--- a/electrum_dash/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/installwizard.py
@@ -558,6 +558,7 @@ Builder.load_string('''
         multiline: False
         size_hint: 1, None
         height: '48dp'
+        on_text: Clock.schedule_once(root.on_text)
     SeedLabel:
         text: root.warning
 
@@ -798,10 +799,17 @@ class LineDialog(WizardDialog):
         WizardDialog.__init__(self, wizard, **kwargs)
         self.title = kwargs.get('title', '')
         self.message = kwargs.get('message', '')
-        self.ids.next.disabled = False
+        self.ids.next.disabled = True
+        self.test = kwargs['test']
+
+    def get_text(self):
+        return self.ids.passphrase_input.text
+
+    def on_text(self, dt):
+        self.ids.next.disabled = not self.test(self.get_text())
 
     def get_params(self, b):
-        return (self.ids.passphrase_input.text,)
+        return (self.get_text(),)
 
 class CLButton(ToggleButton):
     def on_release(self):

--- a/electrum_dash/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/installwizard.py
@@ -900,7 +900,13 @@ class RestoreSeedDialog(WizardDialog):
                 yield w
 
     def update_next_button(self):
-        self.ids.next.disabled = False if self.is_bip39 else not bool(self._test(self.get_text()))
+        from electrum_dash.keystore import bip39_is_checksum_valid
+        text = self.get_text()
+        if self.is_bip39:
+            is_seed, is_wordlist = bip39_is_checksum_valid(text)
+        else:
+            is_seed = bool(self._test(text))
+        self.ids.next.disabled = not is_seed
 
     def on_text(self, dt):
         self.update_next_button()

--- a/electrum_dash/gui/kivy/uix/dialogs/seed_options.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/seed_options.py
@@ -6,6 +6,10 @@ from kivy.lang import Builder
 Builder.load_string('''
 <SeedOptionsDialog@Popup>
     id: popup
+    opt_bip39: False
+    opt_ext: False
+    is_bip39: False
+    is_ext: False
     title: _('Seed Options')
     size_hint: 0.8, 0.8
     pos_hint: {'top':0.9}
@@ -22,16 +26,24 @@ Builder.load_string('''
             size_hint: 1, 0.2
             Label:
                 text: _('Extend Seed')
+                opacity: 1 if root.opt_ext else 0
             CheckBox:
                 id:ext
+                disabled: not root.opt_ext
+                opacity: 1 if root.opt_ext else 0
+                active: root.is_ext
         BoxLayout:
             orientation: 'horizontal'
             size_hint: 1, 0.2
             Label:
                 text: _('BIP39')
                 id:bip39_label
+                opacity: 1 if root.opt_bip39 else 0
             CheckBox:
                 id:bip39
+                disabled: not root.opt_bip39
+                opacity: 1 if root.opt_bip39 else 0
+                active: root.is_bip39
         Widget:
             size_hint: 1, 0.1
         BoxLayout:
@@ -53,13 +65,10 @@ Builder.load_string('''
 
 
 class SeedOptionsDialog(Factory.Popup):
-    def __init__(self, is_ext, is_bip39, callback):
+    def __init__(self, opt_ext, opt_bip39, is_ext, is_bip39, callback):
         Factory.Popup.__init__(self)
-        self.ids.ext.active = is_ext
-        if is_bip39 is None:
-            self.ids.bip39.opacity = 0
-            self.ids.bip39_label.opacity = 0
-            self.ids.bip39.disabled = True
-        else:
-            self.ids.bip39.active = is_bip39
+        self.opt_ext = opt_ext
+        self.opt_bip39 = opt_bip39
+        self.is_ext = is_ext
+        self.is_bip39 = is_bip39
         self.callback = callback


### PR DESCRIPTION
Related to #201

- fix #4326 (upstream 77e0d3745)
- wizard: call on_restore_seed, on_restore_bip39 through self.run. fixes #6895 (upstream b2ab2a9f6)
- kivy wizard: checkum bip39 seeds, because the virtual keyboard imposes the English wordlist (upstream 07b08738a)
- kivy: fix confirm_seed_dialog (broken in 77e0d3745e990e97ddbac5550e399f3e695af788) (upstream 620a6aaf9)
- kivy wizard: verify seed extension (upstream 940654145)