### PR TITLE
kivy/qt: fix tx_type handling

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,3 +1,10 @@
+# Release 4.0.9.3
+
+ * kivy: fix history screen tx_type processing (#207)
+ * qt: pass InvoiceExt data to do_pay_invoice (#209)
+ * kivy/qt: fix tx_type handling (#210)
+
+
 # Release 4.0.9.2
 
  * qt: fix PayToEdit.parse_amount (#172)

--- a/electrum_dash/gui/kivy/main_window.py
+++ b/electrum_dash/gui/kivy/main_window.py
@@ -532,7 +532,7 @@ class ElectrumWindow(App, Logger):
 
     def scan_qr(self, on_complete):
         if platform != 'android':
-            return
+            return self.scan_qr_non_android(on_complete)
         from jnius import autoclass, cast
         from android import activity
         PythonActivity = autoclass('org.kivy.android.PythonActivity')
@@ -554,6 +554,15 @@ class ElectrumWindow(App, Logger):
                 activity.unbind(on_activity_result=on_qr_result)
         activity.bind(on_activity_result=on_qr_result)
         PythonActivity.mActivity.startActivityForResult(intent, 0)
+
+    def scan_qr_non_android(self, on_complete):
+        from electrum_dash import qrscanner
+        try:
+            video_dev = self.electrum_config.get_video_device()
+            data = qrscanner.scan_barcode(video_dev)
+            on_complete(data)
+        except BaseException as e:
+            self.show_error(repr(e))
 
     def do_share(self, data, title):
         if platform != 'android':

--- a/electrum_dash/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/tx_dialog.py
@@ -14,7 +14,7 @@ from kivy.uix.button import Button
 from .question import Question
 from electrum_dash.gui.kivy.i18n import _
 
-from electrum_dash.dash_tx import SPEC_TX_NAMES, tx_header_to_tx_type
+from electrum_dash.dash_tx import SPEC_TX_NAMES
 from electrum_dash.util import InvalidPassword, bfh
 from electrum_dash.address_synchronizer import TX_HEIGHT_LOCAL
 from electrum_dash.transaction import Transaction, PartialTransaction
@@ -144,8 +144,7 @@ class TxDialog(Factory.Popup):
         self.update()
 
     def update(self):
-        raw_tx = str(self.tx)
-        tx_type = tx_header_to_tx_type(bfh(raw_tx[:8]))
+        tx_type = self.tx.tx_type
         if tx_type == 0:
             txid = self.tx.txid()
             tx_type, completed = self.wallet.db.get_ps_tx(txid)

--- a/electrum_dash/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/tx_dialog.py
@@ -147,7 +147,8 @@ class TxDialog(Factory.Popup):
         tx_type = self.tx.tx_type
         if tx_type == 0:
             txid = self.tx.txid()
-            tx_type, completed = self.wallet.db.get_ps_tx(txid)
+            if txid:
+                tx_type, completed = self.wallet.db.get_ps_tx(txid)
         self.title = '%s %s' % (SPEC_TX_NAMES[tx_type], _('Transaction'))
         format_amount = self.app.format_amount_and_units
         tx_details = self.wallet.get_tx_info(self.tx)

--- a/electrum_dash/gui/qt/transaction_dialog.py
+++ b/electrum_dash/gui/qt/transaction_dialog.py
@@ -485,18 +485,17 @@ class BaseTxDialog(QDialog, MessageBoxMixin):
 
         tx_type = self.tx.tx_type
         if tx_type == 0:
+            self.extra_pld_lb.hide()
+            self.extra_pld.hide()
+
             txid = self.tx.txid()
             if txid:
                 tx_type, completed = self.wallet.db.get_ps_tx(txid)
         else:
-            if tx_type:
-                extra_payload = self.tx.extra_payload
-                self.extra_pld.set_extra_data(tx_type, extra_payload)
-                self.extra_pld_lb.show()
-                self.extra_pld.show()
-            else:
-                self.extra_pld_lb.hide()
-                self.extra_pld.hide()
+            extra_payload = self.tx.extra_payload
+            self.extra_pld.set_extra_data(tx_type, extra_payload)
+            self.extra_pld_lb.show()
+            self.extra_pld.show()
         tx_type_name = '%s: %s, ' % (_('Type'), SPEC_TX_NAMES[tx_type])
         self.txid_lb.setText(tx_type_name + _('Transaction ID:'))
 

--- a/electrum_dash/gui/qt/transaction_dialog.py
+++ b/electrum_dash/gui/qt/transaction_dialog.py
@@ -483,11 +483,12 @@ class BaseTxDialog(QDialog, MessageBoxMixin):
         else:
             self.save_button.setToolTip(_("Transaction already saved or not yet signed."))
 
-        if self.tx.tx_type == 0:
+        tx_type = self.tx.tx_type
+        if tx_type == 0:
             txid = self.tx.txid()
-            tx_type, completed = self.wallet.db.get_ps_tx(txid)
+            if txid:
+                tx_type, completed = self.wallet.db.get_ps_tx(txid)
         else:
-            tx_type = self.tx.tx_type
             if tx_type:
                 extra_payload = self.tx.extra_payload
                 self.extra_pld.set_extra_data(tx_type, extra_payload)

--- a/electrum_dash/version.py
+++ b/electrum_dash/version.py
@@ -1,8 +1,8 @@
 import re
 
 
-ELECTRUM_VERSION = '4.0.9.2' # version of the client package
-APK_VERSION = '4.0.9.2'      # read by buildozer.spec
+ELECTRUM_VERSION = '4.0.9.3' # version of the client package
+APK_VERSION = '4.0.9.3'      # read by buildozer.spec
 
 PROTOCOL_VERSION = '1.4.2'   # protocol version requested
 


### PR DESCRIPTION
- kivy: add app.scan_qr_non_android (to simplify debugging on non android platform)
- kivy: rm TxDialog.update tx_type detect (unneeded)
- qt/kivy: do not get PS tx_type on incomplete txs (no txid for incomplete txs)
- qt: fix BaseTxDialog.update tx_type handling

must fix #195