### PR TITLE
qt: fix do_export_history (item key value -> bc_value)

### DIFF
--- a/electrum_dash/gui/qt/history_list.py
+++ b/electrum_dash/gui/qt/history_list.py
@@ -1078,7 +1078,7 @@ class HistoryList(MyTreeView, AcceptFileDragDrop):
                 lines.append([item['txid'],
                               item.get('label', ''),
                               item['confirmations'],
-                              item['value'],
+                              item['bc_value'],
                               item.get('fiat_value', ''),
                               item.get('fee', ''),
                               item.get('fiat_fee', ''),


### PR DESCRIPTION
- qt: fix do_export_history (item key value -> bc_value) after key name chaned
Fix #211