### PR TITLE
add support to save uncompleted multisig wallets

### DIFF
--- a/electrum-dash
+++ b/electrum-dash
@@ -246,6 +246,9 @@ async def run_offline_command(config, config_options, plugins: 'Plugins'):
         db = WalletDB(storage.read(), manual_upgrades=False)
         if db.upgrade_done:
             storage.backup_old_version()
+        if db.check_unfinished_multisig():
+            print_msg("Error: Can not open unfinished multisig wallet.")
+            sys.exit(1)
         wallet = Wallet(db, storage, config=config)
         config_options['wallet'] = wallet
     else:

--- a/electrum_dash/base_wizard.py
+++ b/electrum_dash/base_wizard.py
@@ -24,6 +24,7 @@
 # SOFTWARE.
 
 import os
+import json
 import sys
 import copy
 import traceback
@@ -40,7 +41,8 @@ from .wallet import (Imported_Wallet, Standard_Wallet, Multisig_Wallet,
 from .storage import WalletStorage, StorageEncryptionVersion
 from .wallet_db import WalletDB
 from .i18n import _
-from .util import UserCancelled, InvalidPassword, WalletFileException, UserFacingException
+from .util import (UserCancelled, InvalidPassword, WalletFileException,
+                   UserFacingException, multisig_type)
 from .simple_config import SimpleConfig
 from .plugin import Plugins, HardwarePluginLibraryUnavailable
 from .logging import Logger
@@ -58,6 +60,9 @@ class ScriptTypeNotSupported(Exception): pass
 
 
 class GoBack(Exception): pass
+
+
+class SaveAndExit(Exception): pass
 
 
 class ReRunDialog(Exception): pass
@@ -94,6 +99,9 @@ class BaseWizard(Logger):
         self.keystores = []  # type: List[KeyStore]
         self.is_kivy = config.get('gui') == 'kivy'
         self.seed_type = None
+        self.unfinished_multisig = False
+        self.unfinished_enc_version = None
+        self.unfinished_check_password = None
 
     def set_icon(self, icon):
         pass
@@ -197,6 +205,7 @@ class BaseWizard(Logger):
         assert self.wallet_type in ['standard', 'multisig']
         i = len(self.keystores)
         title = _('Add cosigner') + ' (%d of %d)'%(i+1, self.n) if self.wallet_type=='multisig' else _('Keystore')
+        can_save = (self.wallet_type == 'multisig' and len(self.keystores))
         if self.wallet_type =='standard' or i==0:
             message = _('Do you want to create a new seed, or to restore a wallet using an existing seed?')
             choices = [
@@ -215,7 +224,8 @@ class BaseWizard(Logger):
             if not self.is_kivy:
                 choices.append(('choose_hw_device',  _('Cosign with hardware device')))
 
-        self.choice_dialog(title=title, message=message, choices=choices, run_next=self.run)
+        self.choice_dialog(title=title, message=message, choices=choices,
+                           run_next=self.run, can_save=can_save)
 
     def import_addresses_or_keys(self):
         v = lambda x: keystore.is_address_list(x) or keystore.is_private_key_list(x, raise_on_error=True)
@@ -544,6 +554,44 @@ class BaseWizard(Logger):
                 return xpub_type(ks.xpub)
         return None
 
+    def continue_multisig_setup(self, storage):
+        self.wallet_type = 'multisig'
+        storage_data = json.loads(storage.read())
+        self.data['wallet_type'] = wallet_type = storage_data['wallet_type']
+        m, n = multisig_type(wallet_type)
+        self.n = n
+
+        enc_version = storage.get_encryption_version()
+        self.unfinished_multisig = True
+        self.unfinished_enc_version = enc_version
+        if enc_version == StorageEncryptionVersion.USER_PASSWORD:
+            self.unfinished_check_password = storage.check_password
+
+        self.keystores = []
+        for i in range(1, n):
+            keystore_name = f'x{i}/'
+            if keystore_name not in storage_data:
+                continue
+            ki = keystore.load_keystore(storage_data, keystore_name)
+            self.data[keystore_name] = ki.dump()
+            self.keystores.append(ki)
+
+        self.continue_multisig_setup_dialog(m=m, n=n, keystores=self.keystores,
+                                            run_next=self.choose_keystore)
+
+    def check_need_confirm_password(self):
+        if self.unfinished_check_password is not None:
+            return True
+        for k in self.keystores:
+            if not k.may_have_password():
+                continue
+            try:
+                k.check_password(None)
+            except InvalidPassword:
+                if not self.unfinished_check_password:
+                    self.unfinished_check_password = k.check_password
+        return self.unfinished_check_password is not None
+
     def on_keystore(self, k: KeyStore):
         has_xpub = isinstance(k, keystore.Xpub)
         if has_xpub:
@@ -612,20 +660,39 @@ class BaseWizard(Logger):
         else:
             # reset stack to disable 'back' button in password dialog
             self.reset_stack()
-            # prompt the user to set an arbitrary password
-            self.request_password(
-                run_next=lambda password, encrypt_storage: self.on_password(
-                    password,
-                    encrypt_storage=encrypt_storage,
-                    storage_enc_version=StorageEncryptionVersion.USER_PASSWORD,
-                    encrypt_keystore=encrypt_keystore),
-                force_disable_encrypt_cb=not encrypt_keystore)
+            if self.check_need_confirm_password():
+                enc_version = self.unfinished_enc_version
+                if enc_version == StorageEncryptionVersion.USER_PASSWORD:
+                    encrypt_storage = True
+                else:
+                    encrypt_storage = False
+                # prompt the user to confirm wallet password
+                self.unfinished_confirm_password(
+                    run_next=lambda password: self.on_password(
+                        password,
+                        encrypt_storage=encrypt_storage,
+                        storage_enc_version=StorageEncryptionVersion.USER_PASSWORD,
+                        encrypt_keystore=True))
+            else:
+                # prompt the user to set an arbitrary password
+                self.request_password(
+                    run_next=lambda password, encrypt_storage: self.on_password(
+                        password,
+                        encrypt_storage=encrypt_storage,
+                        storage_enc_version=StorageEncryptionVersion.USER_PASSWORD,
+                        encrypt_keystore=encrypt_keystore),
+                    force_disable_encrypt_cb=not encrypt_keystore)
 
     def on_password(self, password, *, encrypt_storage: bool,
                     storage_enc_version=StorageEncryptionVersion.USER_PASSWORD,
                     encrypt_keystore: bool):
         for k in self.keystores:
             if k.may_have_password():
+                if self.unfinished_multisig:
+                    try:
+                        k.check_password(None)
+                    except InvalidPassword:
+                        continue
                 k.update_password(None, password)
         if self.wallet_type == 'standard':
             self.data['seed_type'] = self.seed_type
@@ -647,12 +714,14 @@ class BaseWizard(Logger):
         self.terminate()
 
     def create_storage(self, path) -> Tuple[WalletStorage, WalletDB]:
-        if os.path.exists(path):
+        if os.path.exists(path) and not self.unfinished_multisig:
             raise Exception('file already exists at path')
         assert self.pw_args, f"pw_args not set?!"
         pw_args = self.pw_args
         self.pw_args = None  # clean-up so that it can get GC-ed
         storage = WalletStorage(path)
+        if self.unfinished_multisig and storage.is_encrypted_with_user_pw():
+            storage.decrypt(pw_args.password)
         if pw_args.encrypt_storage:
             storage.set_password(pw_args.password, enc_version=pw_args.storage_enc_version)
         db = WalletDB('', manual_upgrades=False)

--- a/electrum_dash/daemon.py
+++ b/electrum_dash/daemon.py
@@ -469,6 +469,8 @@ class Daemon(Logger):
             return
         if db.get_action():
             return
+        if db.check_unfinished_multisig():
+            return
         wallet = Wallet(db, storage, config=self.config)
         wallet.start_network(self.network)
         self._wallets[path] = wallet

--- a/electrum_dash/gui/kivy/main_window.py
+++ b/electrum_dash/gui/kivy/main_window.py
@@ -704,7 +704,12 @@ class ElectrumWindow(App, Logger):
             assert not db.requires_upgrade()
             if db.upgrade_done:
                 storage.backup_old_version()
-            self.on_wizard_success(storage, db, password)
+            if db.check_unfinished_multisig():
+                wizard = InstallWizard(self.electrum_config, self.plugins)
+                wizard.path = storage.path
+                wizard.continue_multisig_setup(storage)
+            else:
+                self.on_wizard_success(storage, db, password)
 
     def on_stop(self):
         self.logger.info('on_stop')

--- a/electrum_dash/gui/kivy/uix/dialogs/installwizard.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/installwizard.py
@@ -10,6 +10,8 @@ from kivy.lang import Builder
 from kivy.properties import ObjectProperty, StringProperty, OptionProperty
 from kivy.core.window import Window
 from kivy.uix.button import Button
+from kivy.uix.label import Label
+from kivy.uix.popup import Popup
 from kivy.uix.togglebutton import ToggleButton
 from kivy.utils import platform
 from kivy.uix.widget import Widget
@@ -35,6 +37,7 @@ Builder.load_string('''
 #:import Window kivy.core.window.Window
 #:import _ electrum_dash.gui.kivy.i18n._
 #:import KIVY_GUI_PATH electrum_dash.gui.kivy.KIVY_GUI_PATH
+#:import ComboBox electrum_dash.gui.kivy.uix.combobox.ComboBox
 
 
 <WizardTextInput@TextInput>
@@ -108,6 +111,13 @@ Builder.load_string('''
             spacing: '1dp'
         Widget:
             size_hint: 1, 0.3
+        WizardButton:
+            id: save_btn
+            visible: False
+            text: _('Save and exit')
+            root: root
+            disabled: not self.visible
+            opacity: 1 if self.visible else 0
         GridLayout:
             rows: 1
             spacing: '12dp'
@@ -529,6 +539,50 @@ Builder.load_string('''
             text: _('Share')
             on_release: root.do_share()
 
+
+<ShowContinueMultisigSetupDialog>
+    xpub: ''
+    xpub_name: ''
+    message: ''
+    xpub_message: ''
+    Label:
+        text: root.message
+        color: root.text_color
+        size_hint: 1, None
+        text_size: self.width, None
+        height: self.texture_size[1]
+    GridLayout
+        cols: 1
+        padding: 0, '12dp'
+        spacing: '12dp'
+        size_hint: 1, None
+        height: self.minimum_height
+        ComboBox
+            id: combo
+            size_hint: 1, None
+            height: '48sp'
+            on_key: root.on_xpub_select()
+        SeedButton:
+            id: text_input
+            text: root.xpub
+        SeedLabel:
+            text: root.xpub_message
+    GridLayout
+        rows: 1
+        spacing: '12dp'
+        size_hint: 1, None
+        height: self.minimum_height
+        WizardButton:
+            text: _('QR code')
+            on_release: root.do_qr()
+        WizardButton:
+            text: _('Copy')
+            on_release: root.do_copy()
+        WizardButton:
+            text: _('Share')
+            on_release: root.do_share()
+
+
 <ShowSeedDialog>
     spacing: '12dp'
     value: 'next'
@@ -659,6 +713,9 @@ class WizardDialog(EventsDialog):
         if button is self.ids.back:
             self.wizard.go_back()
             return
+        if button is self.ids.save_btn:
+            self.wizard.run('create_wallet')
+            return
         params = self.get_params(button)
         self.run_next(*params)
 
@@ -767,6 +824,8 @@ class WizardChoiceDialog(WizardDialog):
 
     def __init__(self, wizard, **kwargs):
         super(WizardChoiceDialog, self).__init__(wizard, **kwargs)
+        if kwargs.get('can_save', False):
+            self.ids.save_btn.visible = True
         self.title = kwargs.get('message', '')
         self.message = kwargs.get('message', '')
         choices = kwargs.get('choices', [])
@@ -1025,6 +1084,7 @@ class ShowXpubDialog(WizardDialog):
         WizardDialog.__init__(self, wizard, **kwargs)
         self.xpub = kwargs['xpub']
         self.ids.next.disabled = False
+        self.ids.save_btn.visible = True
 
     def do_copy(self):
         self.app._clipboard.copy(self.xpub)
@@ -1035,6 +1095,65 @@ class ShowXpubDialog(WizardDialog):
     def do_qr(self):
         from .qr_dialog import QRDialog
         popup = QRDialog(_("Master Public Key"), self.xpub, True)
+        popup.open()
+
+
+class ShowContinueMultisigSetupDialog(WizardDialog):
+
+    def __init__(self, wizard, **kwargs):
+        WizardDialog.__init__(self, wizard, **kwargs)
+        self.keystores = keystores = kwargs['keystores']
+        m = kwargs['m']
+        n = kwargs['n']
+        combo = self.ids.combo
+        mpk_ks = keystores[0]
+        mpk_item = _('Master Public Key')
+        if hasattr(mpk_ks, 'label'):
+            mpk_item += f': {mpk_ks.get_type_text()} {mpk_ks.label}'
+        combo.items = [(0, mpk_item)]
+        self.message = ' '.join([
+            _("This wallet is unfinished multisig wallet"
+              " with {} cosigners and {} required signatures.").format(n, m),
+            _("Press 'Next' to finish creation of the wallet.")
+        ])
+        for i in range(len(self.keystores)):
+            if i > 0:
+                ks = keystores[i]
+                cs_item = _('Cosigner {}').format(i+1)
+                if hasattr(ks, 'label'):
+                    cs_item += f': {ks.get_type_text()} {ks.label}'
+                combo.items.append((i, cs_item))
+        combo.key = 0
+        self.ids.next.disabled = False
+
+    def get_params(self, button):
+        return tuple()
+
+    def on_xpub_select(self, *args, **kwargs):
+        combo = self.ids.combo
+        if not combo.items:
+            return
+        i = combo.key
+        self.xpub = self.keystores[i].xpub
+        self.xpub_name = combo.items[i][1]
+        if i == 0:
+            self.xpub_message = ' '.join([
+                _("Here is your master public key."),
+                _("Please share it with your cosigners.")
+            ])
+        else:
+            self.xpub_message = \
+                _("Here is your cosigner {} public key.").format(i+1)
+
+    def do_copy(self):
+        self.app._clipboard.copy(self.xpub)
+
+    def do_share(self):
+        self.app.do_share(self.xpub, self.xpub_name)
+
+    def do_qr(self):
+        from .qr_dialog import QRDialog
+        popup = QRDialog(self.xpub_name, self.xpub, True)
         popup.open()
 
 
@@ -1091,7 +1210,14 @@ class InstallWizard(BaseWizard, Widget):
         if not aborted:
             password = self.pw_args.password
             storage, db = self.create_storage(self.path)
-            self.app.on_wizard_success(storage, db, password)
+            if db.check_unfinished_multisig():
+                lb = Label(text=_('Saved unfinished multisig wallet'))
+                popup = Popup(content=lb, size_hint=(1, 1))
+                popup.bind(on_dismiss=lambda x: self.app.on_wizard_aborted())
+                popup.content.bind(on_touch_down=lambda x, y: popup.dismiss())
+                popup.open()
+            else:
+                self.app.on_wizard_success(storage, db, password)
         else:
             try: os.unlink(self.path)
             except FileNotFoundError: pass
@@ -1148,6 +1274,21 @@ class InstallWizard(BaseWizard, Widget):
         AddXpubDialog(self, **kwargs).open()
 
     def show_xpub_dialog(self, **kwargs): ShowXpubDialog(self, **kwargs).open()
+
+    def continue_multisig_setup_dialog(self, **kwargs):
+        ShowContinueMultisigSetupDialog(self, **kwargs).open()
+
+    def unfinished_confirm_password(self, run_next):
+        def on_success(pw):
+            run_next(pw)
+        popup = PasswordDialog(
+            self.app,
+            check_password=self.unfinished_check_password,
+            on_success=on_success,
+            is_change=False,
+            is_password=True,
+            message=_('Please enter wallet password before continue'))
+        popup.open()
 
     def show_message(self, msg): self.show_error(msg)
 

--- a/electrum_dash/gui/kivy/uix/dialogs/password_dialog.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/password_dialog.py
@@ -354,7 +354,11 @@ class OpenWalletDialog(PasswordDialog):
             if db.upgrade_done:
                 self.storage.backup_old_version()
                 self.app.show_backup_msg()
-            wallet = Wallet(db, self.storage, config=self.app.electrum_config)
-            self.require_password = wallet.has_password()
-            self.pw_check = wallet.check_password
-            self.message = self.enter_pw_message if self.require_password else _('Wallet not encrypted')
+            if db.check_unfinished_multisig():
+                self.require_password = False
+            else:
+                wallet = Wallet(db, self.storage, config=self.app.electrum_config)
+                self.require_password = wallet.has_password()
+                self.pw_check = wallet.check_password
+            self.message = (self.enter_pw_message if self.require_password
+                            else _('Wallet not encrypted'))

--- a/electrum_dash/gui/qt/__init__.py
+++ b/electrum_dash/gui/qt/__init__.py
@@ -313,6 +313,9 @@ class ElectrumGui(Logger):
                 wizard.path = path  # needed by trustedcoin plugin
                 wizard.run('new')
                 storage, db = wizard.create_storage(path)
+                if db.check_unfinished_multisig():
+                    wizard.show_message(_('Saved unfinished multisig wallet'))
+                    return
             else:
                 db = WalletDB(storage.read(), manual_upgrades=False)
                 if db.upgrade_done:
@@ -324,6 +327,12 @@ class ElectrumGui(Logger):
                                    title=_('Information'),
                                    text=storage.backup_message)
                 storage.backup_message = ''
+            if db.check_unfinished_multisig():
+                wizard.continue_multisig_setup(storage)
+                storage, db = wizard.create_storage(storage.path)
+                if db.check_unfinished_multisig():
+                    wizard.show_message(_('Saved unfinished multisig wallet'))
+                    return
         except (UserCancelled, GoBack):
             return
         except WalletAlreadyOpenInMemory as e:

--- a/electrum_dash/gui/qt/installwizard.py
+++ b/electrum_dash/gui/qt/installwizard.py
@@ -14,12 +14,14 @@ from PyQt5.QtCore import QRect, QEventLoop, Qt, pyqtSignal
 from PyQt5.QtGui import QPalette, QPen, QPainter, QPixmap
 from PyQt5.QtWidgets import (QWidget, QDialog, QLabel, QHBoxLayout, QMessageBox,
                              QVBoxLayout, QLineEdit, QFileDialog, QPushButton,
-                             QGridLayout, QSlider, QScrollArea, QApplication)
+                             QGridLayout, QSlider, QScrollArea, QApplication,
+                             QComboBox)
 
 from electrum_dash.wallet import Wallet, Abstract_Wallet
 from electrum_dash.storage import WalletStorage, StorageReadWriteError
 from electrum_dash.util import UserCancelled, InvalidPassword, WalletFileException, get_new_wallet_name
-from electrum_dash.base_wizard import BaseWizard, HWD_SETUP_DECRYPT_WALLET, GoBack, ReRunDialog
+from electrum_dash.base_wizard import (BaseWizard, HWD_SETUP_DECRYPT_WALLET,
+                                       GoBack, ReRunDialog, SaveAndExit)
 from electrum_dash.network import Network
 from electrum_dash.i18n import _
 
@@ -99,6 +101,7 @@ def wizard_dialog(func):
         while True:
             #wizard.logger.debug(f"dialog stack. len: {len(wizard._stack)}. stack: {wizard._stack}")
             wizard.back_button.setText(_('Back') if wizard.can_go_back() else _('Cancel'))
+            wizard.save_button.hide()
             # current dialog
             try:
                 out = func(*args, **kwargs)
@@ -111,6 +114,9 @@ def wizard_dialog(func):
                 else:
                     # to go back from the current dialog, we just let the caller unroll the stack:
                     raise
+            except SaveAndExit:
+                out = tuple()
+                run_next = wizard.create_wallet
             # next dialog
             try:
                 while True:
@@ -158,6 +164,8 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         self.accept_signal.connect(self.accept)
         self.title = QLabel()
         self.main_widget = QWidget()
+        self.save_button = QPushButton(_('Save and exit'), self)
+        self.save_button.hide()
         self.back_button = QPushButton(_("Back"), self)
         self.back_button.setText(_('Back') if self.can_go_back() else _('Cancel'))
         self.next_button = QPushButton(_("Next"), self)
@@ -170,6 +178,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         self.rejected.connect(lambda: self.loop.exit(0))
         self.back_button.clicked.connect(lambda: self.loop.exit(1))
         self.next_button.clicked.connect(lambda: self.loop.exit(2))
+        self.save_button.clicked.connect(lambda: self.loop.exit(3))
         outer_vbox = QVBoxLayout(self)
         inner_vbox = QVBoxLayout()
         inner_vbox.addWidget(self.title)
@@ -192,7 +201,11 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         hbox.addWidget(scroll)
         hbox.setStretchFactor(scroll, 1)
         outer_vbox.addLayout(hbox)
-        outer_vbox.addLayout(Buttons(self.back_button, self.next_button))
+        btns_hbox = QHBoxLayout()
+        btns_hbox.addWidget(self.save_button)
+        btns_hbox.addStretch(1)
+        btns_hbox.addLayout(Buttons(self.back_button, self.next_button))
+        outer_vbox.addLayout(btns_hbox)
         self.set_icon('electrum-dash.png')
         self.show()
         self.raise_()
@@ -427,6 +440,8 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
             raise UserCancelled()
         if result == 1:
             raise GoBack from None
+        if result == 3:
+            raise SaveAndExit from None
         self.title.setVisible(False)
         self.back_button.setEnabled(False)
         self.next_button.setEnabled(False)
@@ -520,6 +535,86 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
         return self.pw_layout(MSG_ENTER_PASSWORD, PW_NEW, force_disable_encrypt_cb)
 
     @wizard_dialog
+    def continue_multisig_setup_dialog(self, m, n, keystores, run_next):
+        msg = ' '.join([
+            _("This wallet is unfinished multisig wallet"
+              " with {} cosigners and {} required signatures.").format(n, m),
+            _("Press 'Next' to finish creation of the wallet.")
+        ])
+        vbox = QVBoxLayout()
+        msg_label = WWLabel(msg)
+        vbox.addWidget(msg_label)
+        cosigners_combobox = QComboBox(self)
+        xpub_label = WWLabel('')
+        xpub_layout = SeedLayout('xpub', icon=False, for_seed_words=False)
+
+        def on_cosigner_changed(i):
+            xpub = keystores[i].xpub
+            xpub_layout.seed_e.setText(xpub)
+            if i == 0:
+                msg = ' '.join([
+                    _("Here is your master public key."),
+                    _("Please share it with your cosigners.")
+                ])
+            else:
+                msg = _("Here is your cosigner {} public key.").format(i+1)
+            xpub_label.setText(msg)
+
+        cosigners_combobox.currentIndexChanged.connect(on_cosigner_changed)
+        mpk_ks = keystores[0]
+        mpk_item = _('Master Public Key')
+        if hasattr(mpk_ks, 'label'):
+            mpk_item += f': {mpk_ks.get_type_text()} {mpk_ks.label}'
+        cosigners_combobox.addItem(mpk_item)
+        for i in range(len(keystores)):
+            if i > 0:
+                ks = keystores[i]
+                cs_item = _('Cosigner {}').format(i+1)
+                if hasattr(ks, 'label'):
+                    cs_item += f': {ks.get_type_text()} {ks.label}'
+                cosigners_combobox.addItem(cs_item)
+        vbox.addWidget(cosigners_combobox)
+        vbox.addWidget(xpub_label)
+        vbox.addLayout(xpub_layout.layout())
+
+        self.exec_layout(vbox, _('Continue multisig wallet setup'))
+        return tuple()
+
+    @wizard_dialog
+    def unfinished_confirm_password(self, run_next):
+        vbox = QVBoxLayout()
+        msg_label = WWLabel(_('Please enter wallet password before continue'))
+        vbox.addWidget(msg_label)
+        hbox = QHBoxLayout()
+        pw_e = PasswordLineEdit('', self)
+        pw_e.setFixedWidth(17 * char_width_in_lineedit())
+        pw_label = QLabel(_('Password') + ':')
+        hbox.addWidget(pw_label)
+        hbox.addWidget(pw_e)
+        hbox.addStretch()
+        vbox.addLayout(hbox)
+        self.set_layout(vbox, title=_('Confirm wallet password'))
+        try:
+            while True:
+                pw_e.setFocus()
+                if self.loop.exec_() != 2:  # 2 = next
+                    raise UserCancelled()
+                password = pw_e.text()
+                try:
+                    self.unfinished_check_password(password)
+                    break
+                except InvalidPassword as e:
+                    self.show_message(title=_('Error'), msg=str(e))
+                    continue
+                except BaseException as e:
+                    self.logger.exception('')
+                    self.show_message(title=_('Error'), msg=repr(e))
+                    raise UserCancelled()
+        finally:
+            pw_e.clear()
+        return password
+
+    @wizard_dialog
     def request_storage_encryption(self, run_next):
         playout = PasswordLayoutForHW(MSG_HW_STORAGE_ENCRYPTION)
         playout.encrypt_cb.setChecked(True)
@@ -585,7 +680,9 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
             raise exc
 
     @wizard_dialog
-    def choice_dialog(self, title, message, choices, run_next):
+    def choice_dialog(self, title, message, choices, run_next, can_save=False):
+        if can_save:
+            self.save_button.show()
         c_values = [x[0] for x in choices]
         c_titles = [x[1] for x in choices]
         clayout = ChoicesLayout(message, c_titles)
@@ -690,6 +787,7 @@ class InstallWizard(QDialog, MessageBoxMixin, BaseWizard):
 
     @wizard_dialog
     def show_xpub_dialog(self, xpub, run_next):
+        self.save_button.show()
         msg = ' '.join([
             _("Here is your master public key."),
             _("Please share it with your cosigners.")

--- a/electrum_dash/gui/stdio.py
+++ b/electrum_dash/gui/stdio.py
@@ -50,6 +50,9 @@ class ElectrumGui:
         db = WalletDB(storage.read(), manual_upgrades=False)
         if db.upgrade_done:
             storage.backup_old_version()
+        if db.check_unfinished_multisig():
+            print('Can not open unfinished multisig wallet')
+            exit()
 
         if getattr(storage, 'backup_message', None):
             print(f'{storage.backup_message}\n')

--- a/electrum_dash/gui/text.py
+++ b/electrum_dash/gui/text.py
@@ -57,6 +57,9 @@ class ElectrumGui:
         db = WalletDB(storage.read(), manual_upgrades=False)
         if db.upgrade_done:
             storage.backup_old_version()
+        if db.check_unfinished_multisig():
+            print('Can not open unfinished multisig wallet')
+            exit()
 
         self.wallet = Wallet(db, storage, config=config)
         self.wallet.start_network(self.network)

--- a/electrum_dash/tests/test_base_wizard.py
+++ b/electrum_dash/tests/test_base_wizard.py
@@ -1,0 +1,127 @@
+import os
+import inspect
+import json
+import shutil
+import tempfile
+
+from electrum_dash.base_wizard import BaseWizard
+from electrum_dash.keystore import BIP32_KeyStore
+from electrum_dash.simple_config import SimpleConfig
+from electrum_dash.storage import WalletStorage, StorageEncryptionVersion
+from electrum_dash.wallet_db import WalletDB, FINAL_SEED_VERSION
+
+from . import TestCaseForTestnet
+
+
+X1 = {
+    'derivation': "m/45'/0",
+    'pw_hash_version': 1,
+    'root_fingerprint': '3f635a63',
+    'type': 'bip32',
+    'xprv': 'tprv8e9ce2psffApayzry2mGdWP2zkFGomo4xgNVj3dyohcaxwiR7vZ'
+            'GtE5dzqCUTah7QoZb716n21QdHptT1d9DYNALyaio5gVyQTHQmy6Fyk9',
+    'xpub': 'tpubDAqenSs7p2rVUT2ergRs2v39ZmmCy6yyXyyH1ZgHDyQyoRyBkKN'
+            's4ihWAyr9b5uuJpuZvUYC9xDabdsoP9As2ZZZmSLEkLEkMDsaoEUaPNo'
+}
+
+X2 = {
+    'derivation': "m/45'/0",
+    'pw_hash_version': 1,
+    'root_fingerprint': 'e54b06c8',
+    'type': 'bip32',
+    'xprv': 'tprv8eFGXNuTxVENvqBHHHGjQ61WaWqmjx9rp4vtZVNhskcBZUbdmD1'
+            'Nws8sGqBttSJUxPLT9VEYNHcHUbXx6UkPCtiQjN5DqCWPmo3bvUW7W5Z',
+    'xpub': 'tpubDAwJfnwi6rv3pJD5AvwKoVfd9YMhuHLmPNXfr1R1J2QaPxrQPbp'
+            'y8MkjSweG9YkwiSi5YAjvuyoezMWH8k18oUyfiHSTUHdqZLQLTY5AtuD'
+}
+
+
+X1_VIEW_ONLY = {
+    'derivation': None,
+    'pw_hash_version': 1,
+    'root_fingerprint': None,
+    'type': 'bip32',
+    'xprv': None,
+    'xpub': 'tpubDAwJfnwi6rv3pJD5AvwKoVfd9YMhuHLmPNXfr1R1J2QaPxrQPbp'
+            'y8MkjSweG9YkwiSi5YAjvuyoezMWH8k18oUyfiHSTUHdqZLQLTY5AtuD'
+}
+
+
+class SimpleWizard(BaseWizard):
+
+    def continue_multisig_setup_dialog(self, m, n, keystores, run_next):
+        self.last_method = inspect.currentframe().f_code.co_name
+        self.last_args = (m, n, keystores, run_next)
+
+
+class BaseWizardTestCase(TestCaseForTestnet):
+
+    def setUp(self):
+        super(BaseWizardTestCase, self).setUp()
+        self.config = SimpleConfig({'electrum_path': self.electrum_path})
+        self.wallet_path = os.path.join(self.electrum_path, "somewallet")
+        self.wizard = SimpleWizard(self.config, None)
+
+    def test_continue_multisig_setup(self):
+        wiz = self.wizard
+        storage = WalletStorage(self.wallet_path)
+        d = {'wallet_type': 'standard', "seed_version": FINAL_SEED_VERSION}
+        d['wallet_type'] = '2of3'
+        d['x1/'] = X1
+        db = WalletDB(json.dumps(d), manual_upgrades=True)
+        assert db.check_unfinished_multisig()
+        db.write(storage)
+        storage = WalletStorage(self.wallet_path)
+        wiz.continue_multisig_setup(storage)
+        assert wiz.unfinished_multisig
+        assert wiz.unfinished_enc_version == StorageEncryptionVersion.PLAINTEXT
+        assert not wiz.unfinished_check_password
+        assert wiz.last_method == 'continue_multisig_setup_dialog'
+        last_args = wiz.last_args
+        assert last_args[0:2] == (2, 3)  # m, n
+        assert last_args[2] == wiz.keystores  # keystores
+        assert len(last_args[2]) == 1
+        k1 = last_args[2][0]
+        assert type(k1) == BIP32_KeyStore
+        assert k1.get_root_fingerprint() == '3f635a63'
+        assert last_args[3] == wiz.choose_keystore  # run_next
+
+        d['x2/'] = X2
+        db = WalletDB(json.dumps(d), manual_upgrades=True)
+        assert db.check_unfinished_multisig()
+        db.write(storage)
+        storage = WalletStorage(self.wallet_path)
+        wiz.continue_multisig_setup(storage)
+        assert wiz.unfinished_multisig
+        assert wiz.unfinished_enc_version == StorageEncryptionVersion.PLAINTEXT
+        assert not wiz.unfinished_check_password
+        assert wiz.last_method == 'continue_multisig_setup_dialog'
+        last_args = wiz.last_args
+        assert last_args[0:2] == (2, 3)  # m, n
+        assert last_args[2] == wiz.keystores  # keystores
+        assert len(last_args[2]) == 2
+        k1, k2 = last_args[2]
+        assert type(k1) == BIP32_KeyStore
+        assert k1.get_root_fingerprint() == '3f635a63'
+        assert type(k2) == BIP32_KeyStore
+        assert k2.get_root_fingerprint() == 'e54b06c8'
+        assert last_args[3] == wiz.choose_keystore  # run_next
+
+    def test_check_need_confirm_password(self):
+        wiz = self.wizard
+        storage = WalletStorage(self.wallet_path)
+        d = {'wallet_type': 'standard', "seed_version": FINAL_SEED_VERSION}
+        d['wallet_type'] = '2of3'
+        d['x1/'] = X1_VIEW_ONLY
+        d['x2/'] = X2
+        db = WalletDB(json.dumps(d), manual_upgrades=True)
+        db.write(storage)
+        storage = WalletStorage(self.wallet_path)
+        wiz.continue_multisig_setup(storage)
+
+        wiz.unfinished_check_password = storage.check_password
+        assert wiz.check_need_confirm_password()
+        wiz.unfinished_check_password = None
+        assert not wiz.check_need_confirm_password()
+        wiz.keystores[1].update_password(None, 'test')
+        assert wiz.check_need_confirm_password()

--- a/electrum_dash/tests/test_wallet_db.py
+++ b/electrum_dash/tests/test_wallet_db.py
@@ -1,0 +1,42 @@
+import json
+
+from electrum_dash.wallet_db import WalletDB, FINAL_SEED_VERSION
+
+from . import SequentialTestCase
+
+
+class WalletDBTestCase(SequentialTestCase):
+
+    def test_check_unfinished_multisig(self):
+        d = {'wallet_type': 'standard', "seed_version": FINAL_SEED_VERSION}
+
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert not db.check_unfinished_multisig()
+
+        d['wallet_type'] = '2of3'
+        d['x1/'] = d['x2/'] = d['x3/'] = 'some data'
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert not db.check_unfinished_multisig()
+
+        del d['x3/']
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert db.check_unfinished_multisig()  # x1/, x2/ pass
+        assert db.check_unfinished_multisig()
+
+        del d['x2/']
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert db.check_unfinished_multisig()  # x1/ pass
+        assert db.check_unfinished_multisig()
+
+        del d['x1/']
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert not db.check_unfinished_multisig()  # no x1/ fails
+
+        d['x1/'] = d['x3/'] = 'some data'
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert not db.check_unfinished_multisig()  # x1/, x3/ fails
+
+        d['x2/'] = 'some data'
+        del d['x1/']
+        db = WalletDB(json.dumps(d), manual_upgrades=False)
+        assert not db.check_unfinished_multisig()  # x2/, x3/ fails

--- a/electrum_dash/wallet_db.py
+++ b/electrum_dash/wallet_db.py
@@ -105,6 +105,29 @@ class WalletDB(JsonDB):
         elif not self._manual_upgrades:
             self.upgrade()
 
+    def check_unfinished_multisig(self):
+        wallet_type = self.data.get('wallet_type')
+        if not wallet_type:
+            return False
+        m_n = multisig_type(wallet_type)
+        if not m_n:
+            return False
+        x1 = self.data.get('x1/')
+        if not x1:
+            return False
+        m, n = m_n
+        next_cosigner = None
+        for i in range(2, n+1):
+            cosigner_name = f'x{i}/'
+            if self.data.get(cosigner_name):
+                if next_cosigner:
+                    return False
+            elif not next_cosigner:
+                next_cosigner = i
+        if not next_cosigner:
+            return False
+        return True
+
     def requires_split(self):
         d = self.get('accounts', {})
         return len(d) > 1


### PR DESCRIPTION
- Add support to save uncompleted multisig wallets and then
 continue setup when cosigners xpub is available.
 
 Related to #192

Some screens:

1. "Save and exit" button is added when saving is possible:

<image src="https://user-images.githubusercontent.com/992125/111175340-008edb80-85b1-11eb-83a2-afaeed43bd27.png" width="250"> <image src="https://user-images.githubusercontent.com/992125/111175216-d9d0a500-85b0-11eb-93a6-870b2bf1bdc2.png" width="350">

2. Continue multisig setup, when already stored xpubs can be viewed (QR can be shown):

<image src="https://user-images.githubusercontent.com/992125/111176064-ad695880-85b1-11eb-82bc-e080d3f5bfdc.png" width="250"> <image src="https://user-images.githubusercontent.com/992125/111176067-ae01ef00-85b1-11eb-803e-addf7562d913.png" width="350">


