### PR TITLE
commands load_wallet: add set current for commands option

### DIFF
--- a/electrum_dash/commands.py
+++ b/electrum_dash/commands.py
@@ -122,7 +122,10 @@ def command(s):
                 if 'wallet_path' in cmd.options and kwargs.get('wallet_path') is None:
                     kwargs['wallet_path'] = daemon.config.get_wallet_path()
                 if cmd.requires_wallet and kwargs.get('wallet') is None:
-                    kwargs['wallet'] = daemon.config.get_wallet_path()
+                    if daemon.current_wallet_path is not None:
+                        kwargs['wallet'] = daemon.current_wallet_path
+                    else:
+                        kwargs['wallet'] = daemon.config.get_wallet_path()
                 if 'wallet' in cmd.options:
                     wallet_path = kwargs.get('wallet', None)
                     if isinstance(wallet_path, str):
@@ -215,9 +218,12 @@ class Commands:
                 for path, w in self.daemon.get_wallets().items()]
 
     @command('n')
-    async def load_wallet(self, wallet_path=None, password=None):
+    async def load_wallet(self, wallet_path=None,
+                          password=None, set_current=False):
         """Open wallet in daemon"""
-        wallet = self.daemon.load_wallet(wallet_path, password, manual_upgrades=False)
+        wallet = self.daemon.load_wallet(wallet_path, password,
+                                         manual_upgrades=False,
+                                         set_current=set_current)
         if wallet is not None:
             run_hook('load_wallet', wallet, None)
         response = wallet is not None
@@ -1045,6 +1051,7 @@ command_options = {
     'from_height': (None, "Only show transactions that confirmed after given block height"),
     'to_height':   (None, "Only show transactions that confirmed before given block height"),
     'iknowwhatimdoing': (None, "Acknowledge that I understand the full implications of what I am about to do"),
+    'set_current': (None, "set wallet as current for commands"),
 }
 
 

--- a/electrum_dash/daemon.py
+++ b/electrum_dash/daemon.py
@@ -407,6 +407,7 @@ class Daemon(Logger):
         self.gui_object = None
         # path -> wallet;   make sure path is standardized.
         self._wallets = {}  # type: Dict[str, Abstract_Wallet]
+        self.current_wallet_path = None
         daemon_jobs = []
         # Setup commands server
         self.commands_server = None
@@ -444,11 +445,14 @@ class Daemon(Logger):
             self.logger.info("taskgroup stopped.")
             self.stopping_soon.set()
 
-    def load_wallet(self, path, password, *, manual_upgrades=True) -> Optional[Abstract_Wallet]:
+    def load_wallet(self, path, password, *, manual_upgrades=True,
+                    set_current=False) -> Optional[Abstract_Wallet]:
         path = standardize_path(path)
         # wizard will be launched if we return
         if path in self._wallets:
             wallet = self._wallets[path]
+            if set_current:
+                self.current_wallet_path = path
             return wallet
         storage = WalletStorage(path)
         if not storage.file_exists():
@@ -477,6 +481,8 @@ class Daemon(Logger):
         wallet = Wallet(db, storage, config=self.config)
         wallet.start_network(self.network)
         self._wallets[path] = wallet
+        if set_current:
+            self.current_wallet_path = path
         return wallet
 
     def add_wallet(self, wallet: Abstract_Wallet) -> None:
@@ -502,6 +508,8 @@ class Daemon(Logger):
         """Returns True iff a wallet was found."""
         path = standardize_path(path)
         wallet = self._wallets.pop(path, None)
+        if self.current_wallet_path == path:
+            self.current_wallet_path = None
         if not wallet:
             return False
         fut = asyncio.run_coroutine_threadsafe(wallet.stop(), self.asyncio_loop)


### PR DESCRIPTION
Add `--set_current` command option for `load_wallet` command,
which allow to run commands where wallet required without additional `wallet_path` option.

Fix: #226