### PR TITLE
Fix kivy: show tx type again

### DIFF
--- a/electrum_dash/gui/kivy/uix/dialogs/settings.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/settings.py
@@ -78,6 +78,12 @@ Builder.load_string('''
                     action: partial(root.boolean_dialog, 'use_change', _('Use change addresses'), self.message)
                 CardSeparator
                 SettingsItem:
+                    status: _('Yes') if root.show_tx_type else _('No')
+                    title: _('Show tx type') + ': ' + self.status
+                    description: _('Show transaction type in wallet history')
+                    action: root.trigger_show_tx_type
+                CardSeparator
+                SettingsItem:
                     title: _('Password')
                     description: _('Change your password') if app._use_single_password else _("Change your password for this wallet.")
                     action: root.change_password
@@ -96,6 +102,7 @@ Builder.load_string('''
 class SettingsDialog(Factory.Popup):
 
     labels_plugin_on = BooleanProperty(False)
+    show_tx_type = BooleanProperty(False)
 
     def __init__(self, app):
         self.app = app
@@ -110,6 +117,8 @@ class SettingsDialog(Factory.Popup):
         self._language_dialog = None
         self._unit_dialog = None
         self._coinselect_dialog = None
+        def_dip2 = not self.app.wallet.psman.unsupported
+        self.show_tx_type = self.config.get('show_dip2_tx_type', def_dip2)
 
     def update(self):
         self.wallet = self.app.wallet
@@ -225,3 +234,9 @@ class SettingsDialog(Factory.Popup):
                 label.status = self.fx_status()
             self._fx_dialog = FxDialog(self.app, self.plugins, self.config, cb)
         self._fx_dialog.open()
+
+    def trigger_show_tx_type(self, dt):
+        self.show_tx_type = show_dip2 = not self.show_tx_type
+        self.config.set_key('show_dip2_tx_type', show_dip2, True)
+        if self.app.history_screen:
+            self.app.history_screen.update(reload_history=False)

--- a/electrum_dash/gui/kivy/uix/ui_screens/history.kv
+++ b/electrum_dash/gui/kivy/uix/ui_screens/history.kv
@@ -59,6 +59,13 @@
             orientation: 'vertical'
             Widget
             CardLabel:
+                color: 0.65, 0.65, 0.95, 1
+                text: root.tx_type
+                shorten: True
+                shorten_from: 'right'
+                font_size: '12sp'
+            Widget
+            CardLabel:
                 color: 0.95, 0.95, 0.95, 1
                 text: root.message
                 shorten: True
@@ -89,7 +96,7 @@
 <HistoryRecycleView@RecycleView>:
     viewclass: 'HistoryItem'
     HistBoxLayout:
-        default_size: None, dp(56)
+        default_size: None, dp(64)
         default_size_hint: 1, None
         size_hint: 1, None
         height: self.minimum_height

--- a/electrum_dash/wallet.py
+++ b/electrum_dash/wallet.py
@@ -921,6 +921,8 @@ class Abstract_Wallet(AddressSynchronizer, ABC):
                 tx_type = tx_item['tx_type']
                 tx_type_name = SPEC_TX_NAMES.get(tx_type, str(tx_type))
                 tx_item['tx_type'] = tx_type_name
+            else:
+                tx_item['tx_type'] = ''
             group_data = tx_item['group_data']
             if group_data:
                 group_delta, group_balance, group_txids = group_data


### PR DESCRIPTION
- kivy: add show tx type to settings
- kivy history.kv: show tx type
- wallet.get_full_history: set empty str tx type when show_dip2 disabled (get_full_history should return with str in tx_type)

Fix #206