### PR TITLE
Qt fix: remove BlockingWaitingDialog use, other qt fixes

### DIFF
--- a/electrum_dash/gui/kivy/uix/dialogs/tx_dialog.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/tx_dialog.py
@@ -242,19 +242,6 @@ class TxDialog(Factory.Popup):
         action_button = self.ids.action_button
         self._action_button_fn(action_button)
 
-    def _add_info_to_tx_from_wallet_and_network(self, tx: PartialTransaction) -> bool:
-        """Returns whether successful."""
-        # note side-effect: tx is being mutated
-        assert isinstance(tx, PartialTransaction)
-        try:
-            # note: this might download input utxos over network
-            # FIXME network code in gui thread...
-            tx.add_info_from_wallet(self.wallet, ignore_network_issues=False)
-        except NetworkException as e:
-            self.app.show_error(repr(e))
-            return False
-        return True
-
     def do_sign(self):
         if self.dropdown:
             self.dropdown.dismiss()

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -1973,7 +1973,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         no_ps_data = psman.is_hw_ks and not psman.enabled
         def make_tx(fee_est):
             tx = self.wallet.make_unsigned_transaction(
-                coins=self.get_coins(min_rounds=min_rounds),
+                coins=inputs,
                 outputs=outputs,
                 fee=fee_est,
                 is_sweep=False,
@@ -2015,14 +2015,14 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             return
 
         cancelled, is_send, password, tx = conf_dlg.run()
+        if cancelled:
+            return
         if tx.tx_type:
             try:
                 tx.extra_payload.check_after_tx_prepared(tx)
             except DashTxError as e:
                 self.show_message(str(e))
                 return
-        if cancelled:
-            return
         if is_send:
             pr = self.payment_request
             self.save_pending_invoice()

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -270,7 +270,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         tabs.addTab(self.create_history_tab(), read_QIcon("tab_history.png"), _('History'))
         tabs.addTab(self.send_tab, read_QIcon("tab_send.png"), _('Send'))
         tabs.addTab(self.receive_tab, read_QIcon("tab_receive.png"), _('Receive'))
-        self.update_avalaible_amount()
+        self.update_available_amount()
 
         def add_optional_tab(tabs, tab, icon, description, name):
             tab.tab_icon = icon
@@ -1178,7 +1178,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         if wallet != self.wallet:
             return
         self.history_model.refresh('update_tabs')
-        self.update_avalaible_amount()
+        self.update_available_amount()
         self.update_receive_address_styling()
         self.request_list.update()
         self.address_list.update()
@@ -1840,7 +1840,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
     def on_ps_cb(self, is_ps):
         if self.max_button.isChecked():
             self.spend_max()
-        self.update_avalaible_amount()
+        self.update_available_amount()
         if is_ps:
             w = self.wallet
             psman = w.psman
@@ -1861,9 +1861,9 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self.set_ps_cb_from_coins(coins)
         else:
             self.ps_cb.setChecked(False)
-        self.update_avalaible_amount()
+        self.update_available_amount()
 
-    def update_avalaible_amount(self, nonlocal_only=False):
+    def update_available_amount(self, nonlocal_only=False):
         if run_hook('abort_send', self):  # This and extra fee hooks added for
             return                        # code consistency (trustedcoin only)
         wallet = self.wallet
@@ -1903,7 +1903,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         if not coins:
             if is_ps:
                 self.ps_cb.setChecked(False)
-            self.update_avalaible_amount()
+            self.update_available_amount()
             if self.max_button.isChecked():
                 self.spend_max()
             return
@@ -1923,7 +1923,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         else:
             if is_ps:
                 self.ps_cb.setChecked(False)
-        self.update_avalaible_amount()
+        self.update_available_amount()
         if self.max_button.isChecked():
             self.spend_max()
 

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -259,6 +259,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         coincontrol_sb = self.create_coincontrol_statusbar()
 
         self.tabs = tabs = QTabWidget(self)
+        self.tabs.currentChanged.connect(self.on_tabs_switch)
         self.send_tab = self.create_send_tab()
         self.receive_tab = self.create_receive_tab()
         self.addresses_tab = self.create_addresses_tab()
@@ -381,6 +382,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
             self._update_check_thread = UpdateCheckThread()
             self._update_check_thread.checked.connect(on_version_received)
             self._update_check_thread.start()
+
+    def on_tabs_switch(self, x):
+        if self.tabs.currentIndex() == self.tabs.indexOf(self.send_tab):
+            self.update_available_amount()
 
     def show_backup_msg(self):
         if getattr(self.wallet.storage, 'backup_message', None):
@@ -1864,8 +1869,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         self.update_available_amount()
 
     def update_available_amount(self, nonlocal_only=False):
-        if run_hook('abort_send', self):  # This and extra fee hooks added for
-            return                        # code consistency (trustedcoin only)
+        if self.tabs.currentIndex() != self.tabs.indexOf(self.send_tab):
+            return
         wallet = self.wallet
         psman = wallet.psman
         is_ps = self.ps_cb.isChecked()

--- a/electrum_dash/gui/qt/main_window.py
+++ b/electrum_dash/gui/qt/main_window.py
@@ -95,7 +95,7 @@ from .util import (read_QIcon, ColorScheme, text_dialog, icon_path, WaitingDialo
                    import_meta_gui, export_meta_gui,
                    filename_field, address_field, char_width_in_lineedit, webopen,
                    TRANSACTION_FILE_EXTENSION_FILTER_ANY, MONOSPACE_FONT,
-                   getOpenFileName, getSaveFileName, BlockingWaitingDialog)
+                   getOpenFileName, getSaveFileName)
 from .util import ButtonsTextEdit, ButtonsLineEdit
 from .installwizard import WIF_HELP_TEXT
 from .history_list import HistoryList, HistoryModel
@@ -3522,22 +3522,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, Logger):
         grid.setRowStretch(len(plugins.descriptions.values()), 1)
         vbox.addLayout(Buttons(CloseButton(d)))
         d.exec_()
-
-    def _add_info_to_tx_from_wallet_and_network(self, tx: PartialTransaction) -> bool:
-        """Returns whether successful."""
-        # note side-effect: tx is being mutated
-        assert isinstance(tx, PartialTransaction)
-        try:
-            # note: this might download input utxos over network
-            BlockingWaitingDialog(
-                self,
-                _("Adding info to tx, from wallet and network..."),
-                lambda: tx.add_info_from_wallet(self.wallet, ignore_network_issues=False),
-            )
-        except NetworkException as e:
-            self.show_error(repr(e))
-            return False
-        return True
 
     def save_transaction_into_wallet(self, tx: Transaction):
         win = self.top_level_window()

--- a/electrum_dash/gui/qt/privatesend_dialog.py
+++ b/electrum_dash/gui/qt/privatesend_dialog.py
@@ -600,7 +600,7 @@ class PSDialog(QDialog, MessageBoxMixin):
                     allow_others_cb.setCheckState(Qt.Unchecked)
             else:
                 psman.allow_others = False
-            self.mwin.update_avalaible_amount()
+            self.mwin.update_available_amount()
         allow_others_cb.stateChanged.connect(on_allow_others_changed)
 
         i = grid.rowCount()

--- a/electrum_dash/gui/qt/transaction_dialog.py
+++ b/electrum_dash/gui/qt/transaction_dialog.py
@@ -281,7 +281,7 @@ class BaseTxDialog(QDialog, MessageBoxMixin):
         action.triggered.connect(lambda: self.copy_to_clipboard(tx=gettx()))
         menu.addAction(action)
 
-        qr_icon = "qrcode_white.png" if ColorScheme.dark_scheme else "qrcode.png"
+        qr_icon = "qrcode.png"
         action = QAction(read_QIcon(qr_icon), _("Show as QR code"), self)
         action.triggered.connect(lambda: self.show_qr(tx=gettx()))
         menu.addAction(action)

--- a/electrum_dash/gui/qt/transaction_dialog.py
+++ b/electrum_dash/gui/qt/transaction_dialog.py
@@ -948,16 +948,12 @@ class PreviewTxDialog(BaseTxDialog, TxEditor):
             self.feerate_e.setAmount(displayed_feerate)
 
         # show/hide fee rounding icon
+        if self.is_ps_tx:  # PS coinchooser does not use fee rounding
+            return
         feerounding = (fee - displayed_fee) if (fee and displayed_fee is not None) else 0
         self.set_feerounding_text(int(feerounding))
         self.feerounding_icon.setToolTip(self.feerounding_text)
         self.feerounding_icon.setVisible(abs(feerounding) >= 1)
-        if not self.is_ps_tx:  # PS coinchooser does not use fee rounding
-            feerounding = (fee - displayed_fee) if fee else 0
-            if abs(feerounding) >= 1:
-                self.set_feerounding_text(int(feerounding))
-                if self.config.get('show_fee', False):
-                    self.feerounding_icon.setVisible(True)
 
     def can_finalize(self):
         return (self.tx is not None

--- a/electrum_dash/gui/qt/transaction_dialog.py
+++ b/electrum_dash/gui/qt/transaction_dialog.py
@@ -55,7 +55,7 @@ from .util import (MessageBoxMixin, read_QIcon, Buttons, icon_path,
                    char_width_in_lineedit, TRANSACTION_FILE_EXTENSION_FILTER_SEPARATE,
                    TRANSACTION_FILE_EXTENSION_FILTER_ONLY_COMPLETE_TX,
                    TRANSACTION_FILE_EXTENSION_FILTER_ONLY_PARTIAL_TX,
-                   BlockingWaitingDialog, getSaveFileName, ColorSchemeItem)
+                   WaitingDialog, getSaveFileName, ColorSchemeItem)
 
 from .fee_slider import FeeSlider, FeeComboBox
 from .confirm_tx_dialog import TxEditor
@@ -91,7 +91,7 @@ def show_transaction(tx: Transaction, *, parent: 'ElectrumWindow', desc=None, pr
         _logger.exception('unable to deserialize the transaction')
         parent.show_critical(_("Dash Electrum was unable to deserialize the transaction:") + "\n" + str(e))
     else:
-        d.show()
+        d.bg_update(lambda x: d.update_and_show())
 
 
 
@@ -241,11 +241,19 @@ class BaseTxDialog(QDialog, MessageBoxMixin):
         # As a result, e.g. we might learn an imported address tx is segwit,
         # or that a beyond-gap-limit address is is_mine.
         # note: this might fetch prev txs over the network.
-        BlockingWaitingDialog(
-            self,
-            _("Adding info to tx, from wallet and network..."),
-            lambda: tx.add_info_from_wallet(self.wallet),
-        )
+
+    def bg_update(self, on_success):
+        parent = self.main_window
+        WaitingDialog(parent,
+                      _("Adding info to tx, from wallet and network..."),
+                      lambda: self.tx.add_info_from_wallet(parent.wallet),
+                      on_success, parent.on_error)
+
+    def update_and_show(self):
+        self.update()
+        self.show()
+        self.raise_()
+        self.activateWindow()
 
     def do_broadcast(self):
         pr = self.main_window.payment_request
@@ -747,7 +755,6 @@ class TxDialog(BaseTxDialog):
     def __init__(self, tx: Transaction, *, parent: 'ElectrumWindow', desc, prompt_if_unsaved):
         BaseTxDialog.__init__(self, parent=parent, desc=desc, prompt_if_unsaved=prompt_if_unsaved, finalized=True)
         self.set_tx(tx)
-        self.update()
 
 
 class PreviewTxDialog(BaseTxDialog, TxEditor):
@@ -771,9 +778,12 @@ class PreviewTxDialog(BaseTxDialog, TxEditor):
         )
         BaseTxDialog.__init__(self, parent=window, desc='', prompt_if_unsaved=False,
                               finalized=False, external_keypairs=external_keypairs)
-        BlockingWaitingDialog(window, _("Preparing transaction..."),
-                              lambda: self.update_tx(fallback_to_zero_fee=True))
-        self.update()
+
+    def bg_update(self, on_success):
+        parent = self.main_window
+        WaitingDialog(parent, _("Preparing transaction..."),
+                      lambda: self.update_tx(fallback_to_zero_fee=True),
+                      on_success, parent.on_error)
 
     def create_fee_controls(self):
 

--- a/electrum_dash/gui/qt/util.py
+++ b/electrum_dash/gui/qt/util.py
@@ -323,31 +323,6 @@ class WaitingDialog(WindowModalDialog):
         self.message_label.setText(msg)
 
 
-class BlockingWaitingDialog(WindowModalDialog):
-    """Shows a waiting dialog whilst running a task.
-    Should be called from the GUI thread. The GUI thread will be blocked while
-    the task is running; the point of the dialog is to provide feedback
-    to the user regarding what is going on.
-    """
-    def __init__(self, parent: QWidget, message: str, task: Callable[[], Any]):
-        assert parent
-        if isinstance(parent, MessageBoxMixin):
-            parent = parent.top_level_window()
-        WindowModalDialog.__init__(self, parent, _("Please wait"))
-        self.message_label = QLabel(message)
-        vbox = QVBoxLayout(self)
-        vbox.addWidget(self.message_label)
-        # show popup
-        self.show()
-        # refresh GUI; needed for popup to appear and for message_label to get drawn
-        QCoreApplication.processEvents()
-        QCoreApplication.processEvents()
-        # block and run given task
-        task()
-        # close popup
-        self.accept()
-
-
 def line_dialog(parent, title, label, ok_label, default=None):
     dialog = WindowModalDialog(parent, title)
     dialog.setMinimumWidth(500)


### PR DESCRIPTION
BlockingWaitingDialog work unstable on older versions of Qt5.
Replace it with WaitingDialog plus corresponding code change.
Some other qt fixes.

- qt: fix pay_onchain_dialog
- qt: fix qrcoin icon in transaction_dialog.py
- qt: fix transaction_dialog.py update_fee_fields
- qt/kivy: rm unused _add_info_to_tx_from_wallet_and_network (RBF)
- qt: use WaitingDialog instead BlockingWaitingDialog