### PR TITLE
Enhance PS gui logging about session timeouts

### DIFF
--- a/electrum_dash/dash_ps.py
+++ b/electrum_dash/dash_ps.py
@@ -660,7 +660,7 @@ class PSManager(Logger, PSKeystoreMixin, PSDataMixin, PSOptsMixin,
                 await self.cleanup_pay_collateral_wfl(force=True)
             else:
                 self.logger.wfl_err(f'Error during creation of pay collateral'
-                                    f' worfklow: {str(e)}')
+                                    f' workflow: {str(e)}')
             type_e = type(e)
             msg = None
             if type_e == NoDynamicFeeEstimates:
@@ -1748,16 +1748,16 @@ class PSManager(Logger, PSKeystoreMixin, PSDataMixin, PSOptsMixin,
             if (type_e == MixSessionTimeout
                     and session and session.state == DSPoolState.QUEUE):
                 denom_amount = util.format_satoshis(session.denom_value)
-                self.logger.info(f'Denominate worfklow {wfl.lid}:'
+                self.logger.info(f'Denominate workflow {wfl.lid}:'
                                  f' timed out in pool state QUEUE,'
                                  f' no peers to mix {denom_amount} DASH')
             elif type_e != asyncio.CancelledError:
                 if wfl:
-                    self.logger.wfl_err(f'Error in denominate worfklow:'
+                    self.logger.wfl_err(f'Error in denominate workflow:'
                                         f' {str(e)}, workflow: {wfl.lid}')
                 else:
                     self.logger.wfl_err(f'Error during creation of denominate'
-                                        f' worfklow: {str(e)}')
+                                        f' workflow: {str(e)}')
                 msg = None
                 if type_e == NoDynamicFeeEstimates:
                     msg = self.NO_DYNAMIC_FEE_MSG.format(str(e))

--- a/electrum_dash/ecc.py
+++ b/electrum_dash/ecc.py
@@ -39,6 +39,8 @@ from .logging import get_logger
 from .ecc_fast import _libsecp256k1, SECP256K1_EC_UNCOMPRESSED
 
 _logger = get_logger(__name__)
+
+
 def string_to_number(b: bytes) -> int:
     return int.from_bytes(b, byteorder='big', signed=False)
 

--- a/electrum_dash/interface.py
+++ b/electrum_dash/interface.py
@@ -146,8 +146,6 @@ class NotificationSession(RPCSession):
 
     async def handle_request(self, request):
         self.maybe_log(f"--> {request}")
-        if request.method == 'masternode.subscribe':
-            return
         try:
             if isinstance(request, Notification):
                 params, result = request.args[:-1], request.args[-1]

--- a/electrum_dash/util.py
+++ b/electrum_dash/util.py
@@ -106,13 +106,6 @@ def base_unit_name_to_decimal_point(unit_name: str) -> int:
         raise UnknownBaseUnit(unit_name) from None
 
 
-# Raised when importing a key that's already in the wallet.
-class AlreadyHaveAddress(Exception):
-    def __init__(self, msg, addr):
-        super(AlreadyHaveAddress, self).__init__(msg)
-        self.addr = addr
-
-
 class NotEnoughFunds(Exception):
     def __str__(self):
         return _("Insufficient funds")
@@ -997,20 +990,6 @@ def parse_json(message):
     except:
         j = None
     return j, message[n+1:]
-
-
-def utfify(arg):
-    """Convert unicode argument to UTF-8.
-
-    Used when loading things that must be serialized.
-    """
-    if isinstance(arg, dict):
-        return {utfify(k): utfify(v) for k, v in arg.items()}
-    elif isinstance(arg, list):
-        return map(utfify, arg)
-    elif isinstance(arg, str):
-        return arg.encode('utf-8')
-    return arg
 
 
 def setup_thread_excepthook():


### PR DESCRIPTION
Follow up to #266

- dash_ps: enhance logging of dsq message timeout (Will write about no peers to mix instead `TimeoutError`)
- remove legacy code, add whitespace in ecc.py