### PR TITLE
Kivy: fix start mixing with protected method

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -10,6 +10,7 @@
  * protx_list: MNList.reset: notify gui, clear protx_info data #270
  * dash_net: rm staled [test.]dnsseed.masternode.io #271
  * Enhance PS gui logging about session timeouts #272
+ * Kivy: fix start mixing with protected method #275
 
 
 # Release 4.1.2.1

--- a/electrum_dash/gui/kivy/main_window.py
+++ b/electrum_dash/gui/kivy/main_window.py
@@ -1426,7 +1426,7 @@ class ElectrumWindow(App, Logger):
     def on_fee(self, event, *arg):
         self.set_fee_status()
 
-    def protected(self, msg, f, args):
+    def protected(self, msg, f, args, on_failure=None):
         if self.electrum_config.get('pin_code'):
             msg += "\n" + _("Enter your PIN code to proceed")
             on_success = lambda pw: f(*args, self.password)
@@ -1435,12 +1435,18 @@ class ElectrumWindow(App, Logger):
                 message = msg,
                 check_password=self.check_pin_code,
                 on_success=on_success,
-                on_failure=lambda: None)
+                on_failure=lambda: on_failure() if on_failure else None)
             d.open()
         else:
+
+            def q_callback(b):
+                if b:
+                    f(*args, self.password)
+                elif on_failure:
+                    on_failure()
             d = Question(
                 msg,
-                lambda b: f(*args, self.password) if b else None,
+                q_callback,
                 yes_str=_("OK"),
                 no_str=_("Cancel"),
                 title=_("Confirm action"))

--- a/electrum_dash/gui/kivy/main_window.py
+++ b/electrum_dash/gui/kivy/main_window.py
@@ -1435,7 +1435,7 @@ class ElectrumWindow(App, Logger):
                 message = msg,
                 check_password=self.check_pin_code,
                 on_success=on_success,
-                on_failure=lambda: on_failure() if on_failure else None)
+                on_failure=lambda: on_failure(*args) if on_failure else None)
             d.open()
         else:
 
@@ -1443,7 +1443,7 @@ class ElectrumWindow(App, Logger):
                 if b:
                     f(*args, self.password)
                 elif on_failure:
-                    on_failure()
+                    on_failure(*args)
             d = Question(
                 msg,
                 q_callback,

--- a/electrum_dash/gui/kivy/uix/dialogs/privatesend.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/privatesend.py
@@ -845,15 +845,13 @@ class PSMixingTab(BoxLayout):
             psman.enable_ps()
 
     def start_mixing(self, prev_kp_state):
-        def on_success_pwd(password):
+        def on_success(password):
             self.psman.start_mixing(password)
 
-        def on_fail_pwd():
+        def on_failure():
             self.psman.keypairs_state = prev_kp_state
 
-        w = self.app.wallet
-        self.app.password_dialog(w, _('Enter your PIN code to start mixing'),
-                                 on_success_pwd, on_fail_pwd)
+        self.app.protected(_('Start mixing'), on_success, (), on_failure)
 
     def toggle_fiat_dn_balance(self, *args):
         if not self.app.fx.is_enabled():

--- a/electrum_dash/gui/kivy/uix/dialogs/question.py
+++ b/electrum_dash/gui/kivy/uix/dialogs/question.py
@@ -33,15 +33,13 @@ Builder.load_string('''
                 size_hint: 0.5, None
                 height: '48dp'
                 on_release:
-                    root.callback(False)
                     popup.dismiss()
             Button:
                 text: root.yes_str
                 size_hint: 0.5, None
                 height: '48dp'
                 on_release:
-                    root.callback(True)
-                    popup.dismiss()
+                    popup.on_yes()
 ''')
 
 
@@ -57,3 +55,11 @@ class Question(Factory.Popup):
         self.title = title or _('Question')
         self.message = msg
         self.callback = callback
+        self.b = False
+
+    def on_yes(self, *args, **kwargs):
+        self.b = True
+        self.dismiss()
+
+    def on_dismiss(self, *args, **kwargs):
+        self.callback(self.b)


### PR DESCRIPTION
- kivy: ElectrumWindow.protected add on_failure, fix start_mixing
- kivy: Question: run callback in on_dismiss with default False arg

Fix #274