### PR TITLE
trezor plugin: allow skip session clear on wallet close

### DIFF
--- a/electrum_dash/plugins/trezor/clientbase.py
+++ b/electrum_dash/plugins/trezor/clientbase.py
@@ -194,7 +194,14 @@ class TrezorClientBase(HardwareClientBase, Logger):
     def close(self):
         '''Called when Our wallet was closed or the device removed.'''
         self.logger.info("closing client")
-        self.clear_session()
+        wallet = getattr(self.handler.win, 'wallet', None)
+        no_lock_on_close = False
+        if wallet:
+            no_lock_on_close = wallet.db.get('trezor_no_lock_on_close', False)
+        if no_lock_on_close:
+            self.logger.info(f"clear session skipped: {self}")
+        else:
+            self.clear_session()
 
     @runs_in_hwd_thread
     def is_uptodate(self):

--- a/electrum_dash/plugins/trezor/qt.py
+++ b/electrum_dash/plugins/trezor/qt.py
@@ -715,6 +715,18 @@ class SettingsDialog(WindowModalDialog):
         settings_layout.addLayout(settings_glayout)
         settings_layout.addStretch(1)
 
+        # Settings tab - Do not clear session on wallet close
+        wallet = window.wallet
+        no_sess_clear = wallet.db.get('trezor_no_lock_on_close', False)
+        no_sess_clear_cb = QCheckBox(_('Do not clear session on wallet close'))
+        no_sess_clear_cb.setChecked(no_sess_clear)
+
+        def on_no_sess_clear_state_changed(x):
+            no_sess_clear = (x == Qt.Checked)
+            wallet.db.put('trezor_no_lock_on_close', no_sess_clear)
+        no_sess_clear_cb.stateChanged.connect(on_no_sess_clear_state_changed)
+        settings_glayout.addWidget(no_sess_clear_cb, 8, 1, 1, -1)
+
         # Advanced tab
         advanced_tab = QWidget()
         advanced_layout = QVBoxLayout(advanced_tab)


### PR DESCRIPTION
- trezor plugin: allow skip session clear on wallet close

Add requested option for trezor plugin.

Fix #291

<image src="https://user-images.githubusercontent.com/992125/131226109-9d257af5-1473-4ea0-9a01-b7267b959d9e.png" width="450">