### PR TITLE
storage: more write attempts, add test_storage.py

### DIFF
--- a/electrum_dash/storage.py
+++ b/electrum_dash/storage.py
@@ -104,7 +104,7 @@ class WalletStorage(Logger):
                 os.replace(temp_path, self.path)
             except PermissionError:
                 # file can be temporarily blocked by windows antivirus software
-                time.sleep(1+0.1*random.random())
+                time.sleep(0.9+0.2*random.random())
                 write_attempts -= 1
                 if write_attempts == 0:
                     raise

--- a/electrum_dash/storage.py
+++ b/electrum_dash/storage.py
@@ -27,6 +27,7 @@ import threading
 import stat
 import hashlib
 import base64
+import random
 import time
 import zlib
 from enum import IntEnum
@@ -59,7 +60,7 @@ class WalletStorage(Logger):
 
     def __init__(self, path):
         Logger.__init__(self)
-        self.write_attempts = 30  # count of write attempts on PermissionError
+        self.write_attempts = 2  # count of write attempts on PermissionError
         self.path = standardize_path(path)
         self._file_exists = bool(self.path and os.path.exists(self.path))
         self.logger.info(f"wallet path {self.path}")
@@ -103,7 +104,7 @@ class WalletStorage(Logger):
                 os.replace(temp_path, self.path)
             except PermissionError:
                 # file can be temporarily blocked by windows antivirus software
-                time.sleep(1)
+                time.sleep(1+0.1*random.random())
                 write_attempts -= 1
                 if write_attempts == 0:
                     raise

--- a/electrum_dash/storage.py
+++ b/electrum_dash/storage.py
@@ -27,6 +27,7 @@ import threading
 import stat
 import hashlib
 import base64
+import time
 import zlib
 from enum import IntEnum
 
@@ -58,6 +59,7 @@ class WalletStorage(Logger):
 
     def __init__(self, path):
         Logger.__init__(self)
+        self.write_attempts = 30  # count of write attempts on PermissionError
         self.path = standardize_path(path)
         self._file_exists = bool(self.path and os.path.exists(self.path))
         self.logger.info(f"wallet path {self.path}")
@@ -81,23 +83,37 @@ class WalletStorage(Logger):
     def write(self, data: str) -> None:
         s = self.encrypt_before_writing(data)
         temp_path = "%s.tmp.%s" % (self.path, os.getpid())
-        with open(temp_path, "w", encoding='utf-8') as f:
-            f.write(s)
-            f.flush()
-            os.fsync(f.fileno())
+        write_attempts = self.write_attempts
+        while write_attempts > 0:
+            with open(temp_path, "w", encoding='utf-8') as f:
+                f.write(s)
+                f.flush()
+                os.fsync(f.fileno())
 
-        try:
-            mode = os.stat(self.path).st_mode
-        except FileNotFoundError:
-            mode = stat.S_IREAD | stat.S_IWRITE
+            try:
+                mode = os.stat(self.path).st_mode
+            except FileNotFoundError:
+                mode = stat.S_IREAD | stat.S_IWRITE
 
-        # assert that wallet file does not exist, to prevent wallet corruption (see issue #5082)
-        if not self.file_exists():
-            assert not os.path.exists(self.path)
-        os.replace(temp_path, self.path)
-        os.chmod(self.path, mode)
-        self._file_exists = True
-        self.logger.info(f"saved {self.path}")
+            # assert that wallet file does not exist,
+            # to prevent wallet corruption (see issue #5082)
+            if not self.file_exists():
+                assert not os.path.exists(self.path)
+            try:
+                os.replace(temp_path, self.path)
+            except PermissionError:
+                # file can be temporarily blocked by windows antivirus software
+                time.sleep(1)
+                write_attempts -= 1
+                if write_attempts == 0:
+                    raise
+                self.logger.error(f"os.replace PermissionError {self.path}, "
+                                  f"left {write_attempts} write attempts")
+                continue
+            os.chmod(self.path, mode)
+            self._file_exists = True
+            self.logger.info(f"saved {self.path}")
+            break
 
     def file_exists(self) -> bool:
         return self._file_exists

--- a/electrum_dash/tests/test_storage.py
+++ b/electrum_dash/tests/test_storage.py
@@ -1,0 +1,51 @@
+import os
+
+from unittest.mock import patch
+
+from electrum_dash.storage import WalletStorage
+
+from . import ElectrumTestCase
+
+
+class ReplaceWithPermissionErrorMock:
+    '''Mock for windows os.replace where PermissionError can happen randomly'''
+
+    def __init__(self, *args, **kwargs):
+        self.error_count = 1
+        self.os_replace = os.replace
+
+    def __call__(self, src, dst):
+        if self.error_count > 0:
+            self.error_count -= 1
+            raise PermissionError
+        else:
+            return self.os_replace(src, dst)
+
+
+class TestWalletStorage(ElectrumTestCase):
+
+    def test_write(self):
+        path = os.path.join(self.electrum_path, 'default_wallet')
+        storage = WalletStorage(path)
+        data = 'testdata'
+        storage.write(data)
+        with open(path, 'r') as fd:
+            assert fd.read() == data
+
+    def test_write_with_permission_error_done(self):
+        path = os.path.join(self.electrum_path, 'default_wallet')
+        storage = WalletStorage(path)
+        data = 'testdata'
+        with patch('os.replace', new_callable=ReplaceWithPermissionErrorMock):
+            storage.write(data)
+        with open(path, 'r') as fd:
+            assert fd.read() == data
+
+    def test_write_with_permission_error_fails(self):
+        path = os.path.join(self.electrum_path, 'default_wallet')
+        storage = WalletStorage(path)
+        storage.write_attempts = 1
+        data = 'testdata'
+        with patch('os.replace', new_callable=ReplaceWithPermissionErrorMock):
+            with self.assertRaises(PermissionError):
+                storage.write(data)


### PR DESCRIPTION
- storage: more write attempts, add test_storage.py

Changes for Win, where antivirus software can block wallet files randomly.

Fix #290