### PR TITLE
Kivy: add "Quick Scan", "Quick Receive" to main screen

### DIFF
--- a/electrum_dash/gui/kivy/uix/screens.py
+++ b/electrum_dash/gui/kivy/uix/screens.py
@@ -345,6 +345,17 @@ class HistoryScreen(CScreen):
         if selected_node is not None:
             history_card.layout_manager.select_node(selected_node)
 
+    def quick_scan(self, *args, **kwargs):
+        app = self.app
+        app.switch_to('send')
+        Clock.schedule_once(lambda dt: app.scan_qr(on_complete=app.on_qr), 0.1)
+
+    def quick_receive(self, *args, **kwargs):
+        app = self.app
+        app.switch_to('receive')
+        receive_screen = app.tabs.ids.receive_screen
+        Clock.schedule_once(lambda dt: receive_screen.new_request(), 0.1)
+
 
 class SendScreen(CScreen, Logger):
 

--- a/electrum_dash/gui/kivy/uix/ui_screens/history.kv
+++ b/electrum_dash/gui/kivy/uix/ui_screens/history.kv
@@ -121,6 +121,20 @@
             bold: True
             size_hint: 1, 0.25
             on_release: app.is_fiat = not app.is_fiat if app.fx.is_enabled() else False
+        BoxLayout:
+            orientation: 'horizontal'
+            size_hint: 1, None
+            height: '48dp'
+            Button:
+                text: _('Quick Scan')
+                size_hint: 0.5, None
+                height: '48dp'
+                on_release: root.quick_scan()
+            Button:
+                text: _('Quick Receive')
+                size_hint: 0.5, None
+                height: '48dp'
+                on_release: root.quick_receive()
         HistoryRecycleView:
             id: history_container
             scroll_type: ['bars', 'content']


### PR DESCRIPTION
- kivy: add "Quick Scan", "Quick Receive" to main screen

<img src="https://user-images.githubusercontent.com/992125/153007390-5dfb9d1d-f100-4720-baf4-0390aeaf38bf.png" width="400">