### PR TITLE
Network: allow blacklist electrum servers

### DIFF
--- a/electrum_dash/gui/kivy/main_window.py
+++ b/electrum_dash/gui/kivy/main_window.py
@@ -57,7 +57,8 @@ from .uix.dialogs import InfoBubble, crash_reporter
 from .uix.dialogs import OutputList, OutputItem
 from .uix.dialogs import TopLabel, RefLabel
 from .uix.dialogs.question import Question
-from .uix.dialogs.dash_kivy import AppInfoDialog, TorWarnDialog
+from .uix.dialogs.dash_kivy import (AppInfoDialog, TorWarnDialog,
+                                    ElectrumServersDialog)
 from .uix.dialogs.warn_dialog import WarnDialog
 from .uix.dialogs.question import Question
 
@@ -871,6 +872,10 @@ class ElectrumWindow(App, Logger):
         else:
             popup = Builder.load_file(KIVY_GUI_PATH + f'/uix/ui_screens/{name}.kv')
             popup.open()
+
+    def electrum_servers_dlg(self):
+        d = ElectrumServersDialog(self)
+        d.open()
 
     @profiler
     def init_ui(self):

--- a/electrum_dash/gui/kivy/uix/ui_screens/network.kv
+++ b/electrum_dash/gui/kivy/uix/ui_screens/network.kv
@@ -13,7 +13,8 @@ Popup:
                 SettingsItem:
                     value: _("{} connections.").format(app.num_nodes) if app.num_nodes else _("Not connected")
                     title: _("Status") + ': ' + self.value
-                    description: _("Connections with Dash Electrum servers")
+                    description: _("Connections with Dash Electrum servers") + ' / '  + _('Blacklist')
+                    action: lambda x: app.electrum_servers_dlg()
 
                 CardSeparator
                 SettingsItem:


### PR DESCRIPTION
- network: allow blacklist electrum servers

Related #323

Added:
- Detect electrum network servers with `tx-txlock-conflict` and blacklist automatically.
- No timeout for removing from blacklist.
- add Qt/Kivy UI to manually `Blacklist`/`Unblacklist` servers.

Qt interface (with right mouse button on items):

<img src="https://user-images.githubusercontent.com/992125/154824999-daf87d63-7b2b-4229-a508-d7bd04233eb4.png" width="500">

Kivy interface (top menu show servers popup now):

<img src="https://user-images.githubusercontent.com/992125/154825041-1e40deeb-630e-4858-bc47-894e2dfda645.png" width="300">

<img src="https://user-images.githubusercontent.com/992125/154825067-4b6242eb-c1aa-4714-a899-63fd632b8b41.png" width="300"><img src="https://user-images.githubusercontent.com/992125/154825068-539be2ef-d2ca-4db2-8383-75733996cdac.png" width="300">

<img src="https://user-images.githubusercontent.com/992125/154825177-eba06060-2682-4cc1-a4ff-8ba0b163b713.png" width="300"><img src="https://user-images.githubusercontent.com/992125/154825070-c4f14707-4966-416c-879b-021d7a884abc.png" width="300">

